### PR TITLE
fix: make rate limiter proxy-aware

### DIFF
--- a/vortai/__init__.py
+++ b/vortai/__init__.py
@@ -10,6 +10,7 @@ from flask import Flask, send_file, request
 from .sdk import GeminiAI
 from flask_cors import CORS
 from flask_limiter import Limiter
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 __all__ = ["create_app", "GeminiAI", "main"]
 import os
@@ -34,6 +35,7 @@ def create_app():
         ),
     )
     CORS(app)  # Enable CORS for all routes
+    app.wsgi_app = ProxyFix(app.wsgi_app)  # Fix for proxy headers
 
     # Initialize rate limiter
     storage_uri = os.environ.get("REDIS_URL") or "memory://"

--- a/vortai/__init__.py
+++ b/vortai/__init__.py
@@ -35,7 +35,13 @@ def create_app():
         ),
     )
     CORS(app)  # Enable CORS for all routes
-    app.wsgi_app = ProxyFix(app.wsgi_app)  # Fix for proxy headers
+
+    # Conditionally apply ProxyFix if PROXY_COUNT is set and > 0
+    proxy_count = int(os.environ.get("PROXY_COUNT", "0"))
+    if proxy_count > 0:
+        app.wsgi_app = ProxyFix(
+            app.wsgi_app, x_for=proxy_count, x_proto=proxy_count, x_host=proxy_count
+        )
 
     # Initialize rate limiter
     storage_uri = os.environ.get("REDIS_URL") or "memory://"


### PR DESCRIPTION
Fixed rate limiter to correctly identify client IPs behind proxies by conditionally applying ProxyFix middleware.

Modified `vortai/__init__.py`: Added conditional ProxyFix based on PROXY_COUNT env var to prevent IP spoofing in local development.