### PR TITLE
fix: bump Node.js version from 18 to 22 for Vite 8 compat

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
     - name: Build React frontend
       run: |
         cd frontend


### PR DESCRIPTION
CI runner has Node.js 18 but Vite 8 requires Node.js 20.19+. Bump to Node.js 22.