### PR TITLE
fix: remove context manager for http.client.HTTPSConnection

### DIFF
--- a/backend/services/mail/providers/resend.py
+++ b/backend/services/mail/providers/resend.py
@@ -38,12 +38,13 @@ class ResendProvider(MailProvider):
         if message.id:
             headers["X-Request-Id"] = message.id
 
+        conn = None
         try:
-            with http.client.HTTPSConnection(HOST, timeout=self.timeout) as conn:
-                conn.request("POST", "/emails", body=payload, headers=headers)
-                resp = conn.getresponse()
-                status = resp.status
-                resp_data = resp.read()
+            conn = http.client.HTTPSConnection(HOST, timeout=self.timeout)
+            conn.request("POST", "/emails", body=payload, headers=headers)
+            resp = conn.getresponse()
+            status = resp.status
+            resp_data = resp.read()
         except Exception as exc:
             logger.exception("Resend request error")
             return MailResult(
@@ -54,6 +55,9 @@ class ResendProvider(MailProvider):
                 retry_count=message.retry_count,
                 error=str(exc),
             )
+        finally:
+            if conn:
+                conn.close()
 
         try:
             response_body = json.loads(resp_data)


### PR DESCRIPTION
Cherry-picked commit 422bf43: removes the context manager for http.client.HTTPSConnection in the Resend provider.