### PR TITLE
fix: include services package in setuptools find for Vercel deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ target-version = ['py312']
 
 [tool.setuptools.packages.find]
 where = ["backend"]
-include = ["palmshed_ai*"]
+include = ["palmshed_ai*", "services*"]
 
 [tool.pytest.ini_options]
 testpaths = ["backend/tests"]


### PR DESCRIPTION
## Problem
The `GET /api/health` endpoint returns HTTP 500 on production deployment.

```
ModuleNotFoundError: No module named 'services'
```

The `services` package (at `backend/services/`) was not included in the setuptools package discovery. Only `palmshed_ai*` packages were included.

## Fix
Added `services*` to the package include pattern in `pyproject.toml`:

```toml
[tool.setuptools.packages.find]
where = ["backend"]
include = ["palmshed_ai*", "services*"]
```

## Verification
- All 71 mail tests pass
- ruff check passes
- black formatting passes
