### PR TITLE
fix: switch models from gemini-2.5-pro to gemini-2.5-flash (free tier quota)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ ENV/
 .coverage
 coverage.xml
 .env.local
+.env.prod

--- a/backend/palmshed_ai/models.py
+++ b/backend/palmshed_ai/models.py
@@ -8,11 +8,11 @@ Centralized location for all model names used in the application.
 
 # Text generation models
 TEXT_MODEL = "gemini-2.5-flash"
-THINKING_MODEL = "gemini-2.5-pro"
-URL_CONTEXT_MODEL = "gemini-2.5-pro"
+THINKING_MODEL = "gemini-2.5-flash"
+URL_CONTEXT_MODEL = "gemini-2.5-flash"
 
 # Image generation model
-IMAGE_MODEL = "imagen-4.0-generate-001"
+IMAGE_MODEL = "gemini-2.5-flash-image"
 
 # Deep Research agent
 DEEP_RESEARCH_MODEL = "deep-research-pro-preview-12-2025"

--- a/backend/verify.py
+++ b/backend/verify.py
@@ -232,7 +232,7 @@ def check_thinking(config: Dict[str, str]) -> Dict[str, Any]:
     thinking = body.get("thinking_summary", [])
     details: Dict[str, Any] = {
         "has_thinking_summary": len(thinking) > 0,
-        "model": "gemini-2.5-pro",
+        "model": "gemini-2.5-flash",
     }
 
     result["status"] = "pass"
@@ -309,7 +309,7 @@ def check_images(config: Dict[str, str]) -> Dict[str, Any]:
         "content_type": content_type,
         "size_bytes": len(body_data),
         "dimensions": f"{w}x{h}",
-        "model": "imagen-4.0-generate-001",
+        "model": "gemini-2.5-flash-image",
     }
     return result
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -20,7 +20,7 @@ print(response.text)
 # Thinking mode
 client = google_genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
 response = client.models.generate_content(
-    model="gemini-2.5-pro",
+    model="gemini-2.5-flash",
     contents="Explain photosynthesis",
     config={"thinking_config": {"include_thoughts": True}}
 )

--- a/docs/imagen-integration.md
+++ b/docs/imagen-integration.md
@@ -37,10 +37,15 @@ except ImportError:
 
 #### 2. Model Configuration (`backend/palmshed_ai/models.py`)
 
-**Updated IMAGE_MODEL:**
+**Current IMAGE_MODEL (default):**
 ```python
-IMAGE_MODEL = "imagen-4.0-generate-001"  # Imagen model
-# Previously: "gemini-2.0-flash-exp-image-generation"
+IMAGE_MODEL = "gemini-2.5-flash-image"  # Gemini-native image generation
+```
+
+**Imagen model (Vertex AI required, optional):**
+```python
+IMAGE_MODEL = "imagen-4.0-generate-001"
+# Requires google-cloud-aiplatform: uv add --group vertex-ai google-cloud-aiplatform
 ```
 
 #### 3. Dependencies

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,11 +63,11 @@ GOOGLE_CLOUD_LOCATION=us-central1
 
 ### Model Configuration
 
-Current working models (as of December 2025):
+Current working models (as of July 2026):
 - **Text generation**: `gemini-2.5-flash`
-- **Thinking mode**: `gemini-2.5-pro` or `gemini-2.5-flash`
+- **Thinking mode**: `gemini-2.5-flash` (switched from `gemini-2.5-pro` due to free tier quota)
 - **URL context**: `gemini-2.5-flash`
-- **Image generation**: `imagen-4.0-generate-001` (requires Vertex AI setup) or Gemini models (limited by free tier)
+- **Image generation**: `gemini-2.5-flash-image` (switched from `imagen-4.0-generate-001` which requires Vertex AI)
 
 ### Vertex AI / Imagen Issues
 


### PR DESCRIPTION
## Problem

3 of 5 endpoints return HTTP 500 on production:

- **Thinking** (`POST /api/generate-with-thinking`): uses `gemini-2.5-pro` which has **zero free tier quota** (429 RESOURCE_EXHAUSTED)
- **Web** (`POST /api/generate-with-url-context`): same — `gemini-2.5-pro` has no free tier quota
- **Images** (`POST /api/generate-image`): `imagen-4.0-generate-001` requires Vertex AI (`google-cloud-aiplatform` is an optional dependency, not installed on Vercel)

## Fix

| Model | Before | After | Reason |
|-------|--------|-------|--------|
| `THINKING_MODEL` | `gemini-2.5-pro` | `gemini-2.5-flash` | flash supports `thinking_config`, has free tier quota |
| `URL_CONTEXT_MODEL` | `gemini-2.5-pro` | `gemini-2.5-flash` | flash supports `UrlContext`, has free tier quota |
| `IMAGE_MODEL` | `imagen-4.0-generate-001` | `gemini-2.5-flash-image` | native Gemini image gen, no Vertex AI needed |

Verified locally:
- `gemini-2.5-flash` + `thinking_config` — works
- `gemini-2.5-flash` + `UrlContext` — works
- `gemini-2.5-flash-image` — accepts image generation requests (confirmed via API, hit local rate limit not model error)

## Files changed
- `backend/palmshed_ai/models.py` — model constants
- `backend/verify.py` — reflect new models in output
- `docs/troubleshooting.md` — update model table
- `docs/api-examples.md` — update thinking example
- `docs/imagen-integration.md` — document new default + Imagen as optional
- `.gitignore` — add .env.prod