### PR TITLE
feat: return actual error messages from API instead of generic 500

### DIFF
--- a/backend/palmshed_ai/routes/api.py
+++ b/backend/palmshed_ai/routes/api.py
@@ -13,6 +13,12 @@ from typing import Any, cast, Dict, Tuple, Union
 from ..sdk import GeminiAI
 
 
+def _error_response(e: Exception) -> Tuple[Response, int]:
+    msg = str(e)
+    status = 429 if "429" in msg or "RESOURCE_EXHAUSTED" in msg else 500
+    return jsonify({"error": msg}), status
+
+
 def is_safe_path(base_path: str, target_path: str) -> bool:
     """Check if target_path is within base_path to prevent path traversal."""
     try:
@@ -51,7 +57,7 @@ def generate_response() -> Union[Response, Tuple[Response, int]]:
 
     except Exception as e:
         logging.error(f"Error in generate_response: {e}")
-        return jsonify({"error": "Internal server error"}), 500
+        return _error_response(e)
 
 
 @api_bp.route("/api/generate-with-thinking", methods=["POST"])
@@ -71,7 +77,7 @@ def generate_response_with_thinking() -> Union[Response, Tuple[Response, int]]:
 
     except Exception as e:
         logging.error(f"Error in generate_response_with_thinking: {e}")
-        return jsonify({"error": "Internal server error"}), 500
+        return _error_response(e)
 
 
 @api_bp.route("/api/generate-with-url-context", methods=["POST"])
@@ -91,7 +97,7 @@ def generate_response_with_url_context() -> Union[Response, Tuple[Response, int]
 
     except Exception as e:
         logging.error(f"Error in generate_response_with_url_context: {e}")
-        return jsonify({"error": "Internal server error"}), 500
+        return _error_response(e)
 
 
 @api_bp.route("/api/text-to-speech", methods=["POST"])
@@ -137,7 +143,7 @@ def text_to_speech() -> Union[Response, Tuple[Response, int]]:
                 os.unlink(filepath)
             except OSError:
                 pass
-        return jsonify({"error": "Internal server error"}), 500
+        return _error_response(e)
 
 
 @api_bp.route("/api/generate-image", methods=["POST"])
@@ -185,7 +191,7 @@ def generate_image() -> Union[Response, Tuple[Response, int]]:
                 os.unlink(filepath)
             except OSError:
                 pass
-        return jsonify({"error": "Internal server error"}), 500
+        return _error_response(e)
 
 
 @api_bp.route("/api/process-text-go", methods=["POST"])

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -241,7 +241,7 @@ def test_generate_api_exception_handling(mock_generate, client):
     assert response.status_code == 500
     data = response.get_json()
     assert "error" in data
-    assert data["error"] == "Internal server error"
+    assert data["error"] == "API Error"
 
 
 @patch("palmshed_ai.routes.api.ai.generate_text_with_thinking")
@@ -253,7 +253,7 @@ def test_thinking_api_exception_handling(mock_thinking, client):
     assert response.status_code == 500
     data = response.get_json()
     assert "error" in data
-    assert data["error"] == "Internal server error"
+    assert data["error"] == "Thinking API Error"
 
 
 @patch("palmshed_ai.routes.api.ai.generate_text_with_url_context")
@@ -265,7 +265,7 @@ def test_url_context_api_exception_handling(mock_url_context, client):
     assert response.status_code == 500
     data = response.get_json()
     assert "error" in data
-    assert data["error"] == "Internal server error"
+    assert data["error"] == "URL Context API Error"
 
 
 @patch("palmshed_ai.routes.api.ai.text_to_speech")
@@ -277,7 +277,7 @@ def test_tts_api_exception_handling(mock_tts, client):
     assert response.status_code == 500
     data = response.get_json()
     assert "error" in data
-    assert data["error"] == "Internal server error"
+    assert data["error"] == "TTS API Error"
 
 
 @patch("palmshed_ai.routes.api.ai.generate_image")
@@ -289,7 +289,7 @@ def test_image_api_exception_handling(mock_image_gen, client):
     assert response.status_code == 500
     data = response.get_json()
     assert "error" in data
-    assert data["error"] == "Internal server error"
+    assert data["error"] == "Image API Error"
 
 
 @patch("palmshed_ai.routes.api.ai.research_topic")

--- a/backend/verify.py
+++ b/backend/verify.py
@@ -187,7 +187,12 @@ def check_canvas(config: Dict[str, str]) -> Dict[str, Any]:
     result["latency"] = elapsed
 
     if status != 200:
-        result["error"] = f"HTTP {status}: {body}"
+        err_detail = body
+        if isinstance(body, dict):
+            err_detail = body.get("error", body)
+        result["error"] = f"HTTP {status}: {err_detail}"
+        if status == 429:
+            result["details"] = {"note": "quota exhausted on free tier for this model"}
         return result
 
     if not isinstance(body, dict) or "response" not in body:
@@ -214,7 +219,12 @@ def check_thinking(config: Dict[str, str]) -> Dict[str, Any]:
     result["latency"] = elapsed
 
     if status != 200:
-        result["error"] = f"HTTP {status}: {body}"
+        err_detail = body
+        if isinstance(body, dict):
+            err_detail = body.get("error", body)
+        result["error"] = f"HTTP {status}: {err_detail}"
+        if status == 429:
+            result["details"] = {"note": "quota exhausted on free tier for this model"}
         return result
 
     if not isinstance(body, dict):
@@ -253,7 +263,12 @@ def check_web(config: Dict[str, str]) -> Dict[str, Any]:
     result["latency"] = elapsed
 
     if status != 200:
-        result["error"] = f"HTTP {status}: {body}"
+        err_detail = body
+        if isinstance(body, dict):
+            err_detail = body.get("error", body)
+        result["error"] = f"HTTP {status}: {err_detail}"
+        if status == 429:
+            result["details"] = {"note": "quota exhausted on free tier for this model"}
         return result
 
     if not isinstance(body, dict) or "response" not in body:
@@ -265,7 +280,7 @@ def check_web(config: Dict[str, str]) -> Dict[str, Any]:
         return result
 
     result["status"] = "pass"
-    result["details"] = {"url_context": "ok", "model": "gemini-2.5-pro"}
+    result["details"] = {"url_context": "ok", "model": "gemini-2.5-flash"}
     return result
 
 
@@ -284,6 +299,10 @@ def check_images(config: Dict[str, str]) -> Dict[str, Any]:
         if isinstance(body_data, dict):
             err_detail = body_data.get("error", body_data)
         result["error"] = f"HTTP {status}: {err_detail}"
+        if status == 429:
+            result["details"] = {
+                "note": "image generation quota exhausted on free tier"
+            }
         return result
 
     if isinstance(body_data, dict):


### PR DESCRIPTION
## Problem

All API endpoints return a generic `{"error": "Internal server error"}` on failure, making debugging impossible from the response body.

## Fix

Replace generic `"Internal server error"` responses with the actual exception message. Maps 429/RESOURCE_EXHAUSTED errors to HTTP 429 status.

### New helper: `_error_response(e)`

- Extracts `str(e)` as the error message
- Returns HTTP 429 if the message contains "429" or "RESOURCE_EXHAUSTED"
- Returns HTTP 500 otherwise

Before:
```json
{"error": "Internal server error"}
```

After:
```json
{"error": "429 RESOURCE_EXHAUSTED. ... quota exceeded ..."}
```

### Verify CLI improvements

All check functions now:
- Extract `error` key from JSON error responses
- Report quota failures with a note: "quota exhausted on free tier for this model"