### PR TITLE
feat: add authentication platform service

### DIFF
--- a/backend/palmshed_ai/routes/api.py
+++ b/backend/palmshed_ai/routes/api.py
@@ -281,4 +281,25 @@ def health_check():
         mail_status["error"] = str(exc)
         logging.warning("Mail service health check failed: %s", exc)
 
-    return jsonify({"status": "ok", "mail": mail_status})
+    auth_status = {"provider": "unknown"}
+    try:
+        from services.auth.config import AuthConfig
+        from services.auth.service import AuthService
+
+        auth_config = AuthConfig.from_env()
+        auth_status["provider"] = auth_config.provider
+        valid, errors = auth_config.is_valid()
+        auth_status["config_valid"] = valid
+        if errors:
+            auth_status["config_errors"] = errors
+        svc = AuthService(config=auth_config)
+        health = svc.health()
+        auth_status["provider"] = health.provider
+        auth_status["config_valid"] = health.config_valid
+        if health.config_errors:
+            auth_status["config_errors"] = health.config_errors
+    except Exception as exc:
+        auth_status["error"] = str(exc)
+        logging.warning("Auth service health check failed: %s", exc)
+
+    return jsonify({"status": "ok", "mail": mail_status, "auth": auth_status})

--- a/backend/services/auth/README.md
+++ b/backend/services/auth/README.md
@@ -1,0 +1,155 @@
+# Auth Service
+
+Provider-agnostic authentication for Palmshed products.
+
+## Architecture
+
+```
+┌─────────────────┐
+│   AuthService    │  ← Public API (single entry point)
+│  register()     │
+│  login()        │
+│  verify()       │
+│  refresh()      │
+│  logout()       │
+│  health()       │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  AuthProvider    │  ← ABC (pluggable backend)
+│  MockAuth       │  ← In-memory, no credentials
+│  JWTAuth        │  ← HMAC-SHA256 JWT (stdlib only)
+└─────────────────┘
+```
+
+## Quick Start
+
+```python
+from services.auth import AuthService
+
+svc = AuthService()
+
+# Register
+result = svc.register("user@example.com", "secure-password")
+if result.status.value == "success":
+    user = result.user
+
+# Login
+result = svc.login("user@example.com", "secure-password")
+if result.status.value == "success":
+    access_token = result.token_pair.access_token
+    refresh_token = result.token_pair.refresh_token
+
+# Verify
+result = svc.verify(access_token)
+if result.status.value == "success":
+    print(f"Authenticated: {result.user.email}")
+
+# Refresh
+result = svc.refresh(refresh_token)
+new_access = result.token_pair.access_token
+
+# Logout
+svc.logout(refresh_token)
+```
+
+## Configuration
+
+All environment variables are read in `AuthConfig.from_env()`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `AUTH_PROVIDER` | `mock` | Provider name (`mock`, `jwt`) |
+| `JWT_SECRET` | `` | HMAC signing key (required for jwt) |
+| `JWT_ALGORITHM` | `HS256` | Signing algorithm |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | Access token TTL |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token TTL |
+
+## Providers
+
+### Mock (default)
+
+No credentials required. Suitable for development and tests.
+
+### JWT
+
+Self-contained tokens using stdlib (`hmac`, `hashlib`, `base64`).
+Requires `JWT_SECRET` to be set.
+
+```bash
+# Generate a secure secret
+python3 -c "import secrets; print(secrets.token_hex(32))"
+export JWT_SECRET="your-256-bit-secret"
+export AUTH_PROVIDER=jwt
+```
+
+## Public API
+
+### `AuthService`
+
+| Method | Returns | Description |
+|---|---|---|
+| `register(email, password)` | `AuthResult` | Create a new user |
+| `login(email, password)` | `AuthResult` | Authenticate and get tokens |
+| `verify(token)` | `AuthResult` | Validate an access token |
+| `refresh(refresh_token)` | `AuthResult` | Get new token pair |
+| `logout(refresh_token)` | `None` | Revoke a refresh token |
+| `health()` | `AuthHealthStatus` | Provider and config status |
+
+### `AuthResult`
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `AuthStatus` | `success`, `failed`, `expired`, `invalid`, `locked` |
+| `user` | `User` | Authenticated user (on success) |
+| `token_pair` | `TokenPair` | Access + refresh tokens (on login/register/refresh) |
+| `error` | `str` | Error message (on failure) |
+| `provider` | `str` | Provider name that handled the request |
+
+## Versioning
+
+This module follows the same versioning policy as the mail service:
+
+- Minor changes (new providers, new fields) — backward compatible
+- Breaking changes (removing methods, changing signatures) — new major version
+- Deprecated items are marked and supported for one minor version cycle
+
+## Adding a Provider
+
+1. Create `providers/your_provider.py`
+2. Implement the `AuthProvider` ABC
+3. Register in `providers/__init__.py`: `ProviderRegistry.register("name", YourProvider)`
+4. Add config fields in `AuthConfig` if needed
+5. Add validation in `AuthConfig.is_valid()`
+
+## Testing
+
+```bash
+# Unit tests
+uv run pytest backend/tests/test_auth.py
+
+# End-to-end verification
+python -m services.auth.verify
+python -m services.auth.verify --email user@example.com --password MyPass123!
+```
+
+## Directory Structure
+
+```
+services/auth/
+├── __init__.py       # Public API re-exports
+├── config.py         # AuthConfig from env
+├── models.py         # User, TokenPair, AuthResult, AuthStatus
+├── service.py        # AuthService (public API)
+├── metrics.py        # AuthMetrics
+├── logging.py        # Audit logging
+├── verify.py         # CLI verification
+├── README.md         # This file
+└── providers/
+    ├── __init__.py   # Auto-registration + factory
+    ├── base.py       # AuthProvider ABC
+    ├── registry.py   # ProviderRegistry
+    ├── mock.py       # MockAuth (in-memory)
+    └── jwt.py        # JWTAuth (stdlib only)
+```

--- a/backend/services/auth/__init__.py
+++ b/backend/services/auth/__init__.py
@@ -1,0 +1,27 @@
+from .config import AuthConfig
+from .metrics import AuthMetrics
+from .models import (
+    AuthHealthStatus,
+    AuthResult,
+    AuthStatus,
+    TokenPair,
+    User,
+)
+from .service import AuthError, AuthService, AuthValidationError
+from .providers import AuthProvider, ProviderRegistry, get_provider
+
+__all__ = [
+    "AuthConfig",
+    "AuthMetrics",
+    "AuthService",
+    "AuthResult",
+    "AuthStatus",
+    "TokenPair",
+    "User",
+    "AuthError",
+    "AuthValidationError",
+    "AuthHealthStatus",
+    "AuthProvider",
+    "ProviderRegistry",
+    "get_provider",
+]

--- a/backend/services/auth/config.py
+++ b/backend/services/auth/config.py
@@ -1,0 +1,35 @@
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class AuthConfig:
+    provider: str = "mock"
+    jwt_secret: str = ""
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 15
+    refresh_token_expire_days: int = 7
+
+    @staticmethod
+    def from_env() -> "AuthConfig":
+        return AuthConfig(
+            provider=os.getenv("AUTH_PROVIDER", "mock").lower(),
+            jwt_secret=os.getenv("JWT_SECRET", ""),
+            jwt_algorithm=os.getenv("JWT_ALGORITHM", "HS256"),
+            access_token_expire_minutes=int(
+                os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "15")
+            ),
+            refresh_token_expire_days=int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7")),
+        )
+
+    def is_valid(self) -> tuple[bool, list[str]]:
+        errors: list[str] = []
+        if self.provider not in ("mock", "jwt"):
+            errors.append(f"Unknown auth provider: {self.provider}")
+        if self.provider == "jwt" and not self.jwt_secret:
+            errors.append("JWT_SECRET is required for JWT provider")
+        if self.access_token_expire_minutes < 1:
+            errors.append("access_token_expire_minutes must be >= 1")
+        if self.refresh_token_expire_days < 1:
+            errors.append("refresh_token_expire_days must be >= 1")
+        return (len(errors) == 0, errors)

--- a/backend/services/auth/logging.py
+++ b/backend/services/auth/logging.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Optional
+
+from .models import AuthResult, AuthStatus
+
+logger = logging.getLogger("palmshed.auth.audit")
+
+
+class AuthLogger:
+    def log_auth_event(
+        self,
+        event: str,
+        email: str,
+        result: AuthResult,
+        user_id: Optional[str] = None,
+    ) -> None:
+        entry = {
+            "event": event,
+            "email": email,
+            "user_id": user_id or "",
+            "status": result.status.value,
+            "provider": result.provider,
+        }
+        if result.error:
+            entry["error"] = result.error
+        logger.info("auth_event", extra=entry)
+
+    def log_failure(
+        self,
+        event: str,
+        email: str,
+        error: str,
+        provider: str = "",
+    ) -> None:
+        entry = {
+            "event": event,
+            "email": email,
+            "status": AuthStatus.FAILED.value,
+            "provider": provider,
+            "error": error,
+        }
+        logger.info("auth_event", extra=entry)

--- a/backend/services/auth/metrics.py
+++ b/backend/services/auth/metrics.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class AuthMetrics:
+    registrations: int = 0
+    logins: int = 0
+    verifications: int = 0
+    refreshes: int = 0
+    failures: int = 0
+    _durations: list[float] = field(default_factory=list, repr=False)
+
+    @property
+    def avg_duration_ms(self) -> float:
+        if not self._durations:
+            return 0.0
+        return (sum(self._durations) / len(self._durations)) * 1000
+
+    def record_registration(self) -> None:
+        self.registrations += 1
+
+    def record_login(self) -> None:
+        self.logins += 1
+
+    def record_verification(self) -> None:
+        self.verifications += 1
+
+    def record_refresh(self) -> None:
+        self.refreshes += 1
+
+    def record_failure(self) -> None:
+        self.failures += 1
+
+    def record_duration(self, seconds: float) -> None:
+        self._durations.append(seconds)
+
+    def snapshot(self) -> dict:
+        return {
+            "registrations": self.registrations,
+            "logins": self.logins,
+            "verifications": self.verifications,
+            "refreshes": self.refreshes,
+            "failures": self.failures,
+            "avg_duration_ms": round(self.avg_duration_ms, 2),
+        }

--- a/backend/services/auth/models.py
+++ b/backend/services/auth/models.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class AuthStatus(Enum):
+    SUCCESS = "success"
+    FAILED = "failed"
+    EXPIRED = "expired"
+    INVALID = "invalid"
+    LOCKED = "locked"
+
+
+@dataclass
+class User:
+    id: str
+    email: str
+    display_name: str = ""
+    is_active: bool = True
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class TokenPair:
+    access_token: str
+    refresh_token: str
+    expires_at: datetime
+    token_type: str = "Bearer"
+
+
+@dataclass
+class AuthResult:
+    status: AuthStatus
+    user: Optional[User] = None
+    token_pair: Optional[TokenPair] = None
+    error: Optional[str] = None
+    provider: str = ""
+
+
+@dataclass
+class AuthHealthStatus:
+    provider: str
+    config_valid: bool
+    config_errors: list[str] = field(default_factory=list)

--- a/backend/services/auth/providers/__init__.py
+++ b/backend/services/auth/providers/__init__.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from ..config import AuthConfig
+from .base import AuthProvider
+from .jwt import JWTAuth
+from .mock import MockAuth
+from .registry import ProviderRegistry
+
+ProviderRegistry.register("mock", MockAuth)
+ProviderRegistry.register("jwt", JWTAuth)
+
+
+def get_provider(config: Optional[AuthConfig] = None) -> AuthProvider:
+    if config is None:
+        config = AuthConfig.from_env()
+    return ProviderRegistry.create(config.provider, config)
+
+
+__all__ = [
+    "AuthProvider",
+    "MockAuth",
+    "JWTAuth",
+    "ProviderRegistry",
+    "get_provider",
+]

--- a/backend/services/auth/providers/base.py
+++ b/backend/services/auth/providers/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+from ..models import AuthResult
+
+
+class AuthProvider(ABC):
+    @abstractmethod
+    def create_user(self, email: str, password: str, **kwargs) -> AuthResult: ...
+
+    @abstractmethod
+    def authenticate(self, email: str, password: str) -> AuthResult: ...
+
+    @abstractmethod
+    def verify_token(self, token: str) -> AuthResult: ...
+
+    @abstractmethod
+    def refresh_token(self, refresh_token: str) -> AuthResult: ...
+
+    @abstractmethod
+    def revoke_token(self, refresh_token: str) -> None: ...

--- a/backend/services/auth/providers/jwt.py
+++ b/backend/services/auth/providers/jwt.py
@@ -1,0 +1,263 @@
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from ..config import AuthConfig
+from ..models import AuthResult, AuthStatus, TokenPair, User
+from .base import AuthProvider
+
+logger = logging.getLogger("palmshed.auth.jwt")
+
+
+def _hash_password(password: str, salt: Optional[str] = None) -> tuple[str, str]:
+    if salt is None:
+        salt = uuid.uuid4().hex[:16]
+    hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), 100000)
+    return hashlib.sha256(salt.encode() + hashed).hexdigest(), salt
+
+
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _base64url_decode(s: str) -> bytes:
+    padding = 4 - len(s) % 4
+    if padding != 4:
+        s += "=" * padding
+    return base64.urlsafe_b64decode(s)
+
+
+def _create_jwt(payload: dict, secret: str, algorithm: str = "HS256") -> str:
+    header = {"alg": algorithm, "typ": "JWT"}
+    header_b64 = _base64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _base64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}"
+    if algorithm == "HS256":
+        sig = hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest()
+    elif algorithm == "HS384":
+        sig = hmac.new(secret.encode(), signing_input.encode(), hashlib.sha384).digest()
+    elif algorithm == "HS512":
+        sig = hmac.new(secret.encode(), signing_input.encode(), hashlib.sha512).digest()
+    else:
+        raise ValueError(f"Unsupported algorithm: {algorithm}")
+    return f"{signing_input}.{_base64url_encode(sig)}"
+
+
+def _verify_jwt(token: str, secret: str, algorithm: str = "HS256") -> Optional[dict]:
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        header_b64, payload_b64, sig_b64 = parts
+        signing_input = f"{header_b64}.{payload_b64}"
+        if algorithm == "HS256":
+            expected = hmac.new(
+                secret.encode(), signing_input.encode(), hashlib.sha256
+            ).digest()
+        elif algorithm == "HS384":
+            expected = hmac.new(
+                secret.encode(), signing_input.encode(), hashlib.sha384
+            ).digest()
+        elif algorithm == "HS512":
+            expected = hmac.new(
+                secret.encode(), signing_input.encode(), hashlib.sha512
+            ).digest()
+        else:
+            return None
+        actual = _base64url_decode(sig_b64)
+        if not hmac.compare_digest(expected, actual):
+            return None
+        payload = json.loads(_base64url_decode(payload_b64))
+        return payload
+    except Exception:
+        return None
+
+
+class JWTAuth(AuthProvider):
+    def __init__(self, config: AuthConfig) -> None:
+        self._secret = config.jwt_secret
+        self._algorithm = config.jwt_algorithm
+        self._access_ttl = config.access_token_expire_minutes
+        self._refresh_ttl = config.refresh_token_expire_days
+        self._users: dict[str, dict] = {}
+        self._refresh_tokens: set[str] = set()
+
+    def create_user(self, email: str, password: str, **kwargs) -> AuthResult:
+        if email in self._users:
+            return AuthResult(
+                status=AuthStatus.FAILED,
+                error=f"User already exists: {email}",
+                provider="jwt",
+            )
+        password_hash, salt = _hash_password(password)
+        user = User(
+            id=str(uuid.uuid4()),
+            email=email,
+            display_name=kwargs.get("display_name", ""),
+        )
+        self._users[email] = {
+            "user": user,
+            "password_hash": password_hash,
+            "salt": salt,
+        }
+        logger.info("JWT user created: %s", email)
+        return AuthResult(status=AuthStatus.SUCCESS, user=user, provider="jwt")
+
+    def authenticate(self, email: str, password: str) -> AuthResult:
+        record = self._users.get(email)
+        if not record:
+            return AuthResult(
+                status=AuthStatus.FAILED,
+                error="Invalid email or password",
+                provider="jwt",
+            )
+        password_hash, _ = _hash_password(password, record["salt"])
+        if record["password_hash"] != password_hash:
+            return AuthResult(
+                status=AuthStatus.FAILED,
+                error="Invalid email or password",
+                provider="jwt",
+            )
+        user = record["user"]
+        if not user.is_active:
+            return AuthResult(
+                status=AuthStatus.LOCKED,
+                error="Account is locked",
+                provider="jwt",
+            )
+        now = datetime.now(timezone.utc)
+        access_payload = {
+            "sub": user.id,
+            "email": user.email,
+            "type": "access",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(minutes=self._access_ttl)).timestamp()),
+        }
+        refresh_payload = {
+            "sub": user.id,
+            "email": user.email,
+            "type": "refresh",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(days=self._refresh_ttl)).timestamp()),
+        }
+        access_token = _create_jwt(access_payload, self._secret, self._algorithm)
+        refresh_token = _create_jwt(refresh_payload, self._secret, self._algorithm)
+        self._refresh_tokens.add(refresh_token)
+        expires_at = now + timedelta(minutes=self._access_ttl)
+        logger.info("JWT login: %s", email)
+        return AuthResult(
+            status=AuthStatus.SUCCESS,
+            user=user,
+            token_pair=TokenPair(
+                access_token=access_token,
+                refresh_token=refresh_token,
+                expires_at=expires_at,
+            ),
+            provider="jwt",
+        )
+
+    def verify_token(self, token: str) -> AuthResult:
+        payload = _verify_jwt(token, self._secret, self._algorithm)
+        if payload is None:
+            return AuthResult(
+                status=AuthStatus.INVALID,
+                error="Invalid token signature",
+                provider="jwt",
+            )
+        exp = payload.get("exp", 0)
+        now = datetime.now(timezone.utc).timestamp()
+        if now > exp:
+            return AuthResult(
+                status=AuthStatus.EXPIRED,
+                error="Token expired",
+                provider="jwt",
+            )
+        email = payload.get("email", "")
+        record = self._users.get(email)
+        if not record:
+            return AuthResult(
+                status=AuthStatus.INVALID,
+                error="User not found",
+                provider="jwt",
+            )
+        return AuthResult(
+            status=AuthStatus.SUCCESS,
+            user=record["user"],
+            provider="jwt",
+        )
+
+    def refresh_token(self, refresh_token_val: str) -> AuthResult:
+        if refresh_token_val not in self._refresh_tokens:
+            return AuthResult(
+                status=AuthStatus.INVALID,
+                error="Invalid refresh token",
+                provider="jwt",
+            )
+        payload = _verify_jwt(refresh_token_val, self._secret, self._algorithm)
+        if payload is None:
+            self._refresh_tokens.discard(refresh_token_val)
+            return AuthResult(
+                status=AuthStatus.INVALID,
+                error="Invalid refresh token signature",
+                provider="jwt",
+            )
+        exp = payload.get("exp", 0)
+        now = datetime.now(timezone.utc).timestamp()
+        if now > exp:
+            self._refresh_tokens.discard(refresh_token_val)
+            return AuthResult(
+                status=AuthStatus.EXPIRED,
+                error="Refresh token expired",
+                provider="jwt",
+            )
+        email = payload.get("email", "")
+        record = self._users.get(email)
+        if not record:
+            return AuthResult(
+                status=AuthStatus.INVALID,
+                error="User not found",
+                provider="jwt",
+            )
+        user = record["user"]
+        new_now = datetime.now(timezone.utc)
+        access_payload = {
+            "sub": user.id,
+            "email": user.email,
+            "type": "access",
+            "iat": int(new_now.timestamp()),
+            "exp": int((new_now + timedelta(minutes=self._access_ttl)).timestamp()),
+        }
+        new_refresh_payload = {
+            "sub": user.id,
+            "email": user.email,
+            "type": "refresh",
+            "iat": int(new_now.timestamp()),
+            "exp": int((new_now + timedelta(days=self._refresh_ttl)).timestamp()),
+        }
+        new_access = _create_jwt(access_payload, self._secret, self._algorithm)
+        new_refresh = _create_jwt(new_refresh_payload, self._secret, self._algorithm)
+        self._refresh_tokens.discard(refresh_token_val)
+        self._refresh_tokens.add(new_refresh)
+        expires_at = new_now + timedelta(minutes=self._access_ttl)
+        return AuthResult(
+            status=AuthStatus.SUCCESS,
+            user=user,
+            token_pair=TokenPair(
+                access_token=new_access,
+                refresh_token=new_refresh,
+                expires_at=expires_at,
+            ),
+            provider="jwt",
+        )
+
+    def revoke_token(self, refresh_token_val: str) -> None:
+        self._refresh_tokens.discard(refresh_token_val)
+
+    def reset(self) -> None:
+        self._users.clear()
+        self._refresh_tokens.clear()

--- a/backend/services/auth/providers/mock.py
+++ b/backend/services/auth/providers/mock.py
@@ -1,0 +1,157 @@
+import hashlib
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from ..config import AuthConfig
+from ..models import AuthResult, AuthStatus, TokenPair, User
+from .base import AuthProvider
+
+logger = logging.getLogger("palmshed.auth.mock")
+
+
+def _hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+class MockAuth(AuthProvider):
+    def __init__(self, config: Optional[AuthConfig] = None) -> None:
+        self._users: dict[str, dict] = {}
+        self._refresh_tokens: dict[str, dict] = {}
+
+    def create_user(self, email: str, password: str, **kwargs) -> AuthResult:
+        if email in self._users:
+            return AuthResult(
+                status=AuthStatus.FAILED,
+                error=f"User already exists: {email}",
+                provider="mock",
+            )
+        user = User(
+            id=str(uuid.uuid4()),
+            email=email,
+            display_name=kwargs.get("display_name", ""),
+        )
+        self._users[email] = {
+            "user": user,
+            "password_hash": _hash_password(password),
+        }
+        logger.info("Mock user created: %s", email)
+        return AuthResult(status=AuthStatus.SUCCESS, user=user, provider="mock")
+
+    def authenticate(self, email: str, password: str) -> AuthResult:
+        record = self._users.get(email)
+        if not record:
+            return AuthResult(
+                status=AuthStatus.FAILED,
+                error="Invalid email or password",
+                provider="mock",
+            )
+        if record["password_hash"] != _hash_password(password):
+            return AuthResult(
+                status=AuthStatus.FAILED,
+                error="Invalid email or password",
+                provider="mock",
+            )
+        user = record["user"]
+        if not user.is_active:
+            return AuthResult(
+                status=AuthStatus.LOCKED,
+                error="Account is locked",
+                provider="mock",
+            )
+        access_token = str(uuid.uuid4())
+        refresh_token = str(uuid.uuid4())
+        expires_at = datetime.now(timezone.utc) + timedelta(minutes=15)
+        self._refresh_tokens[refresh_token] = {
+            "user_id": user.id,
+            "access_token": access_token,
+            "expires_at": expires_at,
+        }
+        token_pair = TokenPair(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+        )
+        logger.info("Mock login: %s", email)
+        return AuthResult(
+            status=AuthStatus.SUCCESS,
+            user=user,
+            token_pair=token_pair,
+            provider="mock",
+        )
+
+    def verify_token(self, token: str) -> AuthResult:
+        for rt, session in self._refresh_tokens.items():
+            if session["access_token"] == token:
+                if datetime.now(timezone.utc) > session["expires_at"]:
+                    return AuthResult(
+                        status=AuthStatus.EXPIRED,
+                        error="Token expired",
+                        provider="mock",
+                    )
+                email = self._find_email_by_user_id(session["user_id"])
+                if not email:
+                    return AuthResult(
+                        status=AuthStatus.INVALID,
+                        error="User not found",
+                        provider="mock",
+                    )
+                return AuthResult(
+                    status=AuthStatus.SUCCESS,
+                    user=self._users[email]["user"],
+                    provider="mock",
+                )
+        return AuthResult(
+            status=AuthStatus.INVALID,
+            error="Invalid token",
+            provider="mock",
+        )
+
+    def refresh_token(self, refresh_token: str) -> AuthResult:
+        session = self._refresh_tokens.get(refresh_token)
+        if not session:
+            return AuthResult(
+                status=AuthStatus.INVALID,
+                error="Invalid refresh token",
+                provider="mock",
+            )
+        email = self._find_email_by_user_id(session["user_id"])
+        if not email:
+            return AuthResult(
+                status=AuthStatus.INVALID,
+                error="User not found",
+                provider="mock",
+            )
+        new_access_token = str(uuid.uuid4())
+        new_refresh_token = str(uuid.uuid4())
+        expires_at = datetime.now(timezone.utc) + timedelta(minutes=15)
+        del self._refresh_tokens[refresh_token]
+        self._refresh_tokens[new_refresh_token] = {
+            "user_id": session["user_id"],
+            "access_token": new_access_token,
+            "expires_at": expires_at,
+        }
+        return AuthResult(
+            status=AuthStatus.SUCCESS,
+            user=self._users[email]["user"],
+            token_pair=TokenPair(
+                access_token=new_access_token,
+                refresh_token=new_refresh_token,
+                expires_at=expires_at,
+            ),
+            provider="mock",
+        )
+
+    def revoke_token(self, refresh_token: str) -> None:
+        self._refresh_tokens.pop(refresh_token, None)
+
+    def _find_email_by_user_id(self, user_id: str) -> Optional[str]:
+        for email, record in self._users.items():
+            if record["user"].id == user_id:
+                return email
+        return None
+
+    def reset(self) -> None:
+        self._users.clear()
+        self._refresh_tokens.clear()

--- a/backend/services/auth/providers/registry.py
+++ b/backend/services/auth/providers/registry.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from ..config import AuthConfig
+from .base import AuthProvider
+
+
+class ProviderRegistry:
+    _providers: dict[str, type[AuthProvider]] = {}
+
+    @classmethod
+    def register(cls, name: str, provider_cls: type[AuthProvider]) -> None:
+        cls._providers[name] = provider_cls
+
+    @classmethod
+    def create(cls, name: str, config: AuthConfig) -> AuthProvider:
+        provider_cls = cls._providers.get(name)
+        if not provider_cls:
+            registered = ", ".join(cls.available())
+            raise ValueError(
+                f"Unknown auth provider '{name}'. Registered: {registered}"
+            )
+        return provider_cls(config)
+
+    @classmethod
+    def available(cls) -> list[str]:
+        return list(cls._providers.keys())
+
+    @classmethod
+    def get(cls, name: str) -> Optional[type[AuthProvider]]:
+        return cls._providers.get(name)

--- a/backend/services/auth/service.py
+++ b/backend/services/auth/service.py
@@ -1,0 +1,139 @@
+import time
+from typing import Optional
+
+from .config import AuthConfig
+from .logging import AuthLogger
+from .metrics import AuthMetrics
+from .models import AuthHealthStatus, AuthResult, AuthStatus
+from .providers import AuthProvider, get_provider
+
+
+class AuthError(Exception):
+    pass
+
+
+class AuthValidationError(AuthError):
+    pass
+
+
+class AuthService:
+    def __init__(
+        self,
+        config: Optional[AuthConfig] = None,
+        provider: Optional[AuthProvider] = None,
+        logger: Optional[AuthLogger] = None,
+        metrics: Optional[AuthMetrics] = None,
+    ) -> None:
+        self.config = config or AuthConfig.from_env()
+        self.provider = provider or get_provider(self.config)
+        self.logger = logger or AuthLogger()
+        self.metrics = metrics or AuthMetrics()
+
+    def register(
+        self,
+        email: str,
+        password: str,
+        **kwargs,
+    ) -> AuthResult:
+        self._validate_email(email)
+        self._validate_password(password)
+
+        t0 = time.monotonic()
+        result = self.provider.create_user(email, password, **kwargs)
+        elapsed = time.monotonic() - t0
+        self.metrics.record_duration(elapsed)
+
+        self.logger.log_auth_event(
+            "register",
+            email,
+            result,
+            user_id=result.user.id if result.user else None,
+        )
+
+        if result.status == AuthStatus.SUCCESS:
+            self.metrics.record_registration()
+        else:
+            self.metrics.record_failure()
+
+        return result
+
+    def login(self, email: str, password: str) -> AuthResult:
+        self._validate_email(email)
+        if not password:
+            raise AuthValidationError("Password is required")
+
+        t0 = time.monotonic()
+        result = self.provider.authenticate(email, password)
+        elapsed = time.monotonic() - t0
+        self.metrics.record_duration(elapsed)
+
+        self.logger.log_auth_event(
+            "login",
+            email,
+            result,
+            user_id=result.user.id if result.user else None,
+        )
+
+        if result.status == AuthStatus.SUCCESS:
+            self.metrics.record_login()
+        else:
+            self.metrics.record_failure()
+
+        return result
+
+    def verify(self, token: str) -> AuthResult:
+        if not token:
+            raise AuthValidationError("Token is required")
+
+        t0 = time.monotonic()
+        result = self.provider.verify_token(token)
+        elapsed = time.monotonic() - t0
+        self.metrics.record_duration(elapsed)
+
+        if result.status == AuthStatus.SUCCESS:
+            self.metrics.record_verification()
+        else:
+            self.metrics.record_failure()
+
+        return result
+
+    def refresh(self, refresh_token: str) -> AuthResult:
+        if not refresh_token:
+            raise AuthValidationError("Refresh token is required")
+
+        t0 = time.monotonic()
+        result = self.provider.refresh_token(refresh_token)
+        elapsed = time.monotonic() - t0
+        self.metrics.record_duration(elapsed)
+
+        if result.status == AuthStatus.SUCCESS:
+            self.metrics.record_refresh()
+        else:
+            self.metrics.record_failure()
+
+        return result
+
+    def logout(self, refresh_token: str) -> None:
+        if not refresh_token:
+            raise AuthValidationError("Refresh token is required")
+        self.provider.revoke_token(refresh_token)
+
+    def health(self) -> AuthHealthStatus:
+        valid, errors = self.config.is_valid()
+        return AuthHealthStatus(
+            provider=self.config.provider,
+            config_valid=valid,
+            config_errors=errors,
+        )
+
+    def _validate_email(self, email: str) -> None:
+        if not email:
+            raise AuthValidationError("Email is required")
+        if "@" not in email or "." not in email.split("@")[-1]:
+            raise AuthValidationError("Invalid email format")
+
+    def _validate_password(self, password: str) -> None:
+        if not password:
+            raise AuthValidationError("Password is required")
+        if len(password) < 8:
+            raise AuthValidationError("Password must be at least 8 characters")

--- a/backend/services/auth/verify.py
+++ b/backend/services/auth/verify.py
@@ -1,0 +1,102 @@
+import argparse
+import sys
+import uuid
+
+from .config import AuthConfig
+from .service import AuthService
+
+
+def verify(args: argparse.Namespace) -> int:
+    config = AuthConfig.from_env()
+    provider = config.provider
+
+    valid, errors = config.is_valid()
+    if not valid:
+        for e in errors:
+            print(f"CONFIG ERROR: {e}")
+        return 1
+
+    print(f"Provider:     {provider}")
+    print()
+
+    if provider == "mock":
+        print("WARNING: AUTH_PROVIDER=mock — no real authentication.")
+        print("Set AUTH_PROVIDER=jwt and JWT_SECRET to test real JWT tokens.")
+        print()
+
+    try:
+        svc = AuthService(config=config)
+    except Exception as exc:
+        print(f"ERROR: Failed to initialize AuthService: {exc}")
+        return 1
+
+    email = args.email or f"test-{uuid.uuid4().hex[:8]}@example.com"
+    password = args.password or "TestPassword123!"
+
+    print("=== Register ===")
+    result = svc.register(email=email, password=password)
+    if result.status.value != "success":
+        print(f"FAILED: {result.error}")
+        return 1
+    print(f"User ID:  {result.user.id}")
+    print(f"Email:    {result.user.email}")
+    print()
+
+    print("=== Login ===")
+    result = svc.login(email=email, password=password)
+    if result.status.value != "success":
+        print(f"FAILED: {result.error}")
+        return 1
+    print(f"Access:   {result.token_pair.access_token[:40]}...")
+    print(f"Refresh:  {result.token_pair.refresh_token[:40]}...")
+    print(f"Expires:  {result.token_pair.expires_at}")
+    access_token = result.token_pair.access_token
+    refresh_token = result.token_pair.refresh_token
+    print()
+
+    print("=== Verify Access Token ===")
+    result = svc.verify(token=access_token)
+    if result.status.value != "success":
+        print(f"FAILED: {result.error}")
+        return 1
+    print(f"User:     {result.user.email}")
+    print()
+
+    print("=== Refresh Tokens ===")
+    result = svc.refresh(refresh_token=refresh_token)
+    if result.status.value != "success":
+        print(f"FAILED: {result.error}")
+        return 1
+    print(f"New Access:   {result.token_pair.access_token[:40]}...")
+    print(f"New Refresh:  {result.token_pair.refresh_token[:40]}...")
+    print()
+
+    print("=== Logout ===")
+    svc.logout(refresh_token=result.token_pair.refresh_token)
+    print("OK")
+    print()
+
+    print("=== Health ===")
+    health = svc.health()
+    print(f"Provider:     {health.provider}")
+    print(f"Config valid: {health.config_valid}")
+    print()
+
+    print("All auth checks passed.")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify auth service end-to-end",
+    )
+    parser.add_argument("--email", help="Email to use for verification")
+    parser.add_argument("--password", help="Password to use for verification")
+
+    args = parser.parse_args()
+
+    sys.exit(verify(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,768 @@
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+# --- Architecture boundary tests ---
+
+
+class TestArchitecture:
+    """Enforce service boundaries: auth must not import application modules."""
+
+    FORBIDDEN_MODULES = [
+        "flask",
+        "django",
+        "react",
+        "jsx",
+        "palmshed_ai",
+        "templates",
+    ]
+
+    @pytest.mark.parametrize("module", FORBIDDEN_MODULES)
+    def test_auth_never_imports_application_modules(self, module):
+
+        for mod in sys.modules:
+            if mod.startswith("services.auth"):
+                assert module not in mod, f"{mod} imports {module}"
+
+    @pytest.mark.parametrize("module", FORBIDDEN_MODULES)
+    def test_providers_never_import_application_code(self, module):
+        for mod_name in ("services.auth.providers.mock", "services.auth.providers.jwt"):
+            mod = sys.modules.get(mod_name)
+            if mod:
+                src = mod.__file__ or ""
+                with open(src) as f:
+                    content = f.read()
+                for forbidden in self.FORBIDDEN_MODULES:
+                    # Allow self-references and stdlib
+                    if forbidden in ("os", "sys"):
+                        continue
+                    assert (
+                        forbidden not in content
+                    ), f"{mod_name} references {forbidden}"
+
+    def test_providers_use_base_class(self):
+        from services.auth.providers.base import AuthProvider
+        from services.auth.providers.mock import MockAuth
+        from services.auth.providers.jwt import JWTAuth
+
+        assert issubclass(MockAuth, AuthProvider)
+        assert issubclass(JWTAuth, AuthProvider)
+
+    def test_config_is_single_source_of_env(self):
+        for mod_name in (
+            "services.auth.models",
+            "services.auth.service",
+            "services.auth.metrics",
+            "services.auth.logging",
+            "services.auth.providers.base",
+            "services.auth.providers.registry",
+            "services.auth.providers.mock",
+            "services.auth.providers.jwt",
+        ):
+            mod = sys.modules.get(mod_name)
+            if mod and hasattr(mod, "__file__") and mod.__file__:
+                src = mod.__file__
+                with open(src) as f:
+                    content = f.read()
+                lines_with_osenv = [
+                    (i + 1, line.strip())
+                    for i, line in enumerate(content.split("\n"))
+                    if "os.environ" in line or "os.getenv" in line
+                ]
+                assert (
+                    not lines_with_osenv
+                ), f"{mod_name} reads os.environ at lines: {lines_with_osenv}"
+
+    def test_service_accepts_only_valid_inputs(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+
+        with pytest.raises(Exception):
+            svc.register(email="", password="pass")
+
+        with pytest.raises(Exception):
+            svc.register(email="not-an-email", password="pass")
+
+        with pytest.raises(Exception):
+            svc.register(email="a@b.com", password="short")
+
+    def test_health_status_provider_included(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        health = svc.health()
+        assert health.provider
+        assert isinstance(health.config_valid, bool)
+
+
+# --- Model tests ---
+
+
+class TestAuthModels:
+    def test_user_creation(self):
+        from services.auth.models import User
+
+        user = User(id="1", email="test@example.com")
+        assert user.id == "1"
+        assert user.email == "test@example.com"
+        assert user.is_active is True
+        assert user.display_name == ""
+
+    def test_user_with_display_name(self):
+        from services.auth.models import User
+
+        user = User(id="1", email="test@example.com", display_name="Test User")
+        assert user.display_name == "Test User"
+
+    def test_token_pair_creation(self):
+        from services.auth.models import TokenPair
+
+        now = datetime.now(timezone.utc)
+        tp = TokenPair(
+            access_token="access123",
+            refresh_token="refresh123",
+            expires_at=now,
+        )
+        assert tp.access_token == "access123"
+        assert tp.refresh_token == "refresh123"
+        assert tp.token_type == "Bearer"
+
+    def test_auth_result_success(self):
+        from services.auth.models import AuthResult, AuthStatus, User
+
+        result = AuthResult(
+            status=AuthStatus.SUCCESS,
+            user=User(id="1", email="test@example.com"),
+            provider="mock",
+        )
+        assert result.status == AuthStatus.SUCCESS
+        assert result.user.email == "test@example.com"
+        assert result.error is None
+
+    def test_auth_result_failure(self):
+        from services.auth.models import AuthResult, AuthStatus
+
+        result = AuthResult(
+            status=AuthStatus.FAILED,
+            error="Invalid credentials",
+            provider="mock",
+        )
+        assert result.status == AuthStatus.FAILED
+        assert result.error == "Invalid credentials"
+
+    def test_auth_status_values(self):
+        from services.auth.models import AuthStatus
+
+        assert AuthStatus.SUCCESS.value == "success"
+        assert AuthStatus.FAILED.value == "failed"
+        assert AuthStatus.EXPIRED.value == "expired"
+        assert AuthStatus.INVALID.value == "invalid"
+        assert AuthStatus.LOCKED.value == "locked"
+
+    def test_auth_health_status(self):
+        from services.auth.models import AuthHealthStatus
+
+        hs = AuthHealthStatus(provider="mock", config_valid=True)
+        assert hs.provider == "mock"
+        assert hs.config_valid is True
+        assert hs.config_errors == []
+
+    def test_auth_health_status_with_errors(self):
+        from services.auth.models import AuthHealthStatus
+
+        hs = AuthHealthStatus(
+            provider="jwt", config_valid=False, config_errors=["JWT_SECRET missing"]
+        )
+        assert hs.config_valid is False
+        assert "JWT_SECRET missing" in hs.config_errors
+
+
+# --- Config tests ---
+
+
+class TestAuthConfig:
+    def test_default_config(self):
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig()
+        assert config.provider == "mock"
+        assert config.jwt_secret == ""
+        assert config.jwt_algorithm == "HS256"
+        assert config.access_token_expire_minutes == 15
+        assert config.refresh_token_expire_days == 7
+
+    def test_config_validation_valid_mock(self):
+        from services.auth.config import AuthConfig
+
+        valid, errors = AuthConfig().is_valid()
+        assert valid
+        assert errors == []
+
+    def test_config_validation_valid_jwt(self):
+        from services.auth.config import AuthConfig
+
+        valid, errors = AuthConfig(provider="jwt", jwt_secret="mysecret").is_valid()
+        assert valid
+        assert errors == []
+
+    def test_config_validation_missing_jwt_secret(self):
+        from services.auth.config import AuthConfig
+
+        valid, errors = AuthConfig(provider="jwt").is_valid()
+        assert not valid
+        assert "JWT_SECRET is required" in errors[0]
+
+    def test_config_validation_invalid_provider(self):
+        from services.auth.config import AuthConfig
+
+        valid, errors = AuthConfig(provider="unknown").is_valid()
+        assert not valid
+        assert "Unknown auth provider" in errors[0]
+
+    def test_from_env_defaults(self):
+        from services.auth.config import AuthConfig
+
+        with patch.dict(os.environ, {}, clear=True):
+            config = AuthConfig.from_env()
+            assert config.provider == "mock"
+            assert config.jwt_secret == ""
+
+    def test_from_env_override(self):
+        from services.auth.config import AuthConfig
+
+        with patch.dict(
+            os.environ,
+            {
+                "AUTH_PROVIDER": "jwt",
+                "JWT_SECRET": "super-secret",
+                "JWT_ALGORITHM": "HS384",
+                "ACCESS_TOKEN_EXPIRE_MINUTES": "30",
+                "REFRESH_TOKEN_EXPIRE_DAYS": "14",
+            },
+        ):
+            config = AuthConfig.from_env()
+            assert config.provider == "jwt"
+            assert config.jwt_secret == "super-secret"
+            assert config.jwt_algorithm == "HS384"
+            assert config.access_token_expire_minutes == 30
+            assert config.refresh_token_expire_days == 14
+
+
+# --- Metrics tests ---
+
+
+class TestAuthMetrics:
+    def test_initial_state(self):
+        from services.auth.metrics import AuthMetrics
+
+        m = AuthMetrics()
+        assert m.registrations == 0
+        assert m.logins == 0
+        assert m.verifications == 0
+        assert m.refreshes == 0
+        assert m.failures == 0
+        assert m.avg_duration_ms == 0.0
+
+    def test_record_counts(self):
+        from services.auth.metrics import AuthMetrics
+
+        m = AuthMetrics()
+        m.record_registration()
+        m.record_login()
+        m.record_verification()
+        m.record_refresh()
+        m.record_failure()
+        assert m.registrations == 1
+        assert m.logins == 1
+        assert m.verifications == 1
+        assert m.refreshes == 1
+        assert m.failures == 1
+
+    def test_average_duration(self):
+        from services.auth.metrics import AuthMetrics
+
+        m = AuthMetrics()
+        m.record_duration(0.1)
+        m.record_duration(0.3)
+        assert round(m.avg_duration_ms, 1) == 200.0
+
+    def test_snapshot(self):
+        from services.auth.metrics import AuthMetrics
+
+        m = AuthMetrics()
+        m.record_registration()
+        m.record_login()
+        snap = m.snapshot()
+        assert snap["registrations"] == 1
+        assert snap["logins"] == 1
+        assert "avg_duration_ms" in snap
+
+
+# --- Mock provider tests ---
+
+
+class TestMockAuth:
+    def test_create_user_returns_success(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        result = provider.create_user("test@example.com", "password123")
+        assert result.status.value == "success"
+        assert result.user.email == "test@example.com"
+
+    def test_create_user_duplicate(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        provider.create_user("dup@example.com", "password123")
+        result = provider.create_user("dup@example.com", "password123")
+        assert result.status.value == "failed"
+        assert "already exists" in result.error
+
+    def test_login_success(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        provider.create_user("login@example.com", "mypassword")
+        result = provider.authenticate("login@example.com", "mypassword")
+        assert result.status.value == "success"
+        assert result.token_pair is not None
+        assert result.token_pair.access_token
+        assert result.token_pair.refresh_token
+
+    def test_login_wrong_password(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        provider.create_user("user@example.com", "correct")
+        result = provider.authenticate("user@example.com", "wrong")
+        assert result.status.value == "failed"
+
+    def test_login_unknown_user(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        result = provider.authenticate("nobody@example.com", "password")
+        assert result.status.value == "failed"
+        assert "Invalid email or password" in result.error
+
+    def test_verify_token_valid(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        provider.create_user("verify@example.com", "password")
+        login_result = provider.authenticate("verify@example.com", "password")
+        token = login_result.token_pair.access_token
+
+        result = provider.verify_token(token)
+        assert result.status.value == "success"
+        assert result.user.email == "verify@example.com"
+
+    def test_verify_token_invalid(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        result = provider.verify_token("invalid-token")
+        assert result.status.value == "invalid"
+
+    def test_refresh_token(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        provider.create_user("refresh@example.com", "password")
+        login_result = provider.authenticate("refresh@example.com", "password")
+        old_refresh = login_result.token_pair.refresh_token
+
+        result = provider.refresh_token(old_refresh)
+        assert result.status.value == "success"
+        assert result.token_pair.access_token != login_result.token_pair.access_token
+        assert result.token_pair.refresh_token != old_refresh
+        # Old refresh token should be invalidated
+        old_result = provider.refresh_token(old_refresh)
+        assert old_result.status.value == "invalid"
+
+    def test_revoke_token(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        provider.create_user("revoke@example.com", "password")
+        login_result = provider.authenticate("revoke@example.com", "password")
+        refresh = login_result.token_pair.refresh_token
+
+        provider.revoke_token(refresh)
+        result = provider.refresh_token(refresh)
+        assert result.status.value == "invalid"
+
+    def test_reset(self):
+        from services.auth.providers.mock import MockAuth
+
+        provider = MockAuth()
+        provider.create_user("reset@example.com", "password")
+        assert len(provider._users) == 1
+        provider.reset()
+        assert len(provider._users) == 0
+        assert len(provider._refresh_tokens) == 0
+
+
+# --- JWT provider tests ---
+
+
+class TestJWTAuth:
+    def test_create_user_returns_success(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        result = provider.create_user("test@example.com", "password123")
+        assert result.status.value == "success"
+        assert result.user.email == "test@example.com"
+
+    def test_create_user_duplicate(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("dup@example.com", "password123")
+        result = provider.create_user("dup@example.com", "password123")
+        assert result.status.value == "failed"
+
+    def test_login_success(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("login@example.com", "mypassword")
+        result = provider.authenticate("login@example.com", "mypassword")
+        assert result.status.value == "success"
+        assert result.token_pair is not None
+
+    def test_login_wrong_password(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("user@example.com", "correct")
+        result = provider.authenticate("user@example.com", "wrong")
+        assert result.status.value == "failed"
+
+    def test_verify_token_valid(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("verify@example.com", "password")
+        login_result = provider.authenticate("verify@example.com", "password")
+        token = login_result.token_pair.access_token
+
+        result = provider.verify_token(token)
+        assert result.status.value == "success"
+        assert result.user.email == "verify@example.com"
+
+    def test_verify_token_tampered(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        result = provider.verify_token("tampered.token.here")
+        assert result.status.value == "invalid"
+
+    def test_verify_token_wrong_secret(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config1 = AuthConfig(provider="jwt", jwt_secret="secret1")
+        config2 = AuthConfig(provider="jwt", jwt_secret="secret2")
+        provider1 = JWTAuth(config1)
+        provider2 = JWTAuth(config2)
+
+        provider1.create_user("test@example.com", "password")
+        login_result = provider1.authenticate("test@example.com", "password")
+        token = login_result.token_pair.access_token
+
+        result = provider2.verify_token(token)
+        assert result.status.value == "invalid"
+
+    def test_refresh_token(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("refresh@example.com", "password")
+        login_result = provider.authenticate("refresh@example.com", "password")
+        old_refresh = login_result.token_pair.refresh_token
+
+        result = provider.refresh_token(old_refresh)
+        assert result.status.value == "success"
+        assert result.token_pair is not None
+
+    def test_refresh_token_invalid(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        result = provider.refresh_token("invalid-refresh-token")
+        assert result.status.value == "invalid"
+
+    def test_revoke_token(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("revoke@example.com", "password")
+        login_result = provider.authenticate("revoke@example.com", "password")
+        refresh = login_result.token_pair.refresh_token
+
+        provider.revoke_token(refresh)
+        result = provider.refresh_token(refresh)
+        assert result.status.value == "invalid"
+
+    def test_jwt_token_has_correct_structure(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("struct@example.com", "password")
+        result = provider.authenticate("struct@example.com", "password")
+
+        access = result.token_pair.access_token
+        parts = access.split(".")
+        assert len(parts) == 3
+
+    def test_reset(self):
+        from services.auth.providers.jwt import JWTAuth
+        from services.auth.config import AuthConfig
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-secret-key")
+        provider = JWTAuth(config)
+        provider.create_user("reset@example.com", "password")
+        assert len(provider._users) == 1
+        provider.reset()
+        assert len(provider._users) == 0
+        assert len(provider._refresh_tokens) == 0
+
+
+# --- Provider registry tests ---
+
+
+class TestProviderRegistry:
+    def test_register_and_create(self):
+        from services.auth.providers.registry import ProviderRegistry
+        from services.auth.providers.mock import MockAuth
+        from services.auth.config import AuthConfig
+
+        ProviderRegistry.register("test_provider", MockAuth)
+        provider = ProviderRegistry.create("test_provider", AuthConfig())
+        assert isinstance(provider, MockAuth)
+
+    def test_unknown_provider_raises(self):
+        from services.auth.providers.registry import ProviderRegistry
+        from services.auth.config import AuthConfig
+
+        with pytest.raises(ValueError, match="Unknown auth provider"):
+            ProviderRegistry.create("nonexistent", AuthConfig())
+
+    def test_available_includes_registered(self):
+        from services.auth.providers.registry import ProviderRegistry
+
+        available = ProviderRegistry.available()
+        assert "mock" in available
+        assert "jwt" in available
+
+    def test_get_returns_none_for_unknown(self):
+        from services.auth.providers.registry import ProviderRegistry
+
+        assert ProviderRegistry.get("nonexistent") is None
+
+    def test_get_returns_class(self):
+        from services.auth.providers.registry import ProviderRegistry
+        from services.auth.providers.mock import MockAuth
+
+        cls = ProviderRegistry.get("mock")
+        assert cls is MockAuth
+
+
+# --- Auth service tests ---
+
+
+class TestAuthService:
+    def test_register_success(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        result = svc.register("newuser@example.com", "SecurePass123!")
+        assert result.status.value == "success"
+        assert result.user.email == "newuser@example.com"
+        assert result.user.id
+
+    def test_register_duplicate(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.register("dup@example.com", "SecurePass123!")
+        result = svc.register("dup@example.com", "SecurePass123!")
+        assert result.status.value == "failed"
+
+    def test_register_invalid_email(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        with pytest.raises(Exception, match="Invalid email"):
+            svc.register("not-an-email", "SecurePass123!")
+
+    def test_register_short_password(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        with pytest.raises(Exception, match="at least 8"):
+            svc.register("user@example.com", "short")
+
+    def test_login_success(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.register("login-test@example.com", "SecurePass123!")
+        result = svc.login("login-test@example.com", "SecurePass123!")
+        assert result.status.value == "success"
+        assert result.token_pair is not None
+        assert result.token_pair.access_token
+        assert result.token_pair.refresh_token
+
+    def test_login_wrong_password(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.register("loginfail@example.com", "SecurePass123!")
+        result = svc.login("loginfail@example.com", "wrongpassword")
+        assert result.status.value == "failed"
+
+    def test_login_nonexistent_user(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        result = svc.login("nobody@example.com", "password")
+        assert result.status.value == "failed"
+
+    def test_verify_valid_token(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.register("verify-me@example.com", "SecurePass123!")
+        login_result = svc.login("verify-me@example.com", "SecurePass123!")
+        token = login_result.token_pair.access_token
+
+        result = svc.verify(token)
+        assert result.status.value == "success"
+        assert result.user.email == "verify-me@example.com"
+
+    def test_verify_invalid_token(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        result = svc.verify("invalid-token")
+        assert result.status.value == "invalid"
+
+    def test_refresh_success(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.register("refresh-svc@example.com", "SecurePass123!")
+        login_result = svc.login("refresh-svc@example.com", "SecurePass123!")
+        old_refresh = login_result.token_pair.refresh_token
+
+        result = svc.refresh(old_refresh)
+        assert result.status.value == "success"
+        assert result.token_pair.access_token
+        assert result.token_pair.refresh_token != old_refresh
+
+    def test_refresh_invalid_token(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        result = svc.refresh("invalid-refresh-token")
+        assert result.status.value == "invalid"
+
+    def test_logout(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.register("logout@example.com", "SecurePass123!")
+        login_result = svc.login("logout@example.com", "SecurePass123!")
+        refresh = login_result.token_pair.refresh_token
+
+        svc.logout(refresh)
+        result = svc.refresh(refresh)
+        assert result.status.value == "invalid"
+
+    def test_health(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        health = svc.health()
+        assert health.provider == "mock"
+        assert health.config_valid is True
+        assert health.config_errors == []
+
+    def test_metrics_recorded_on_success(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.register("metrics@example.com", "SecurePass123!")
+        svc.login("metrics@example.com", "SecurePass123!")
+        assert svc.metrics.registrations == 1
+        assert svc.metrics.logins == 1
+
+    def test_metrics_recorded_on_failure(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        svc.login("noone@example.com", "wrongpass")
+        assert svc.metrics.failures == 1
+
+    def test_service_works_with_jwt_provider(self):
+        from services.auth.service import AuthService
+        from services.auth.config import AuthConfig
+        from services.auth.providers.jwt import JWTAuth
+
+        config = AuthConfig(provider="jwt", jwt_secret="test-service-secret")
+        provider = JWTAuth(config)
+        svc = AuthService(config=config, provider=provider)
+
+        reg = svc.register("jwt-svc@example.com", "SecurePass123!")
+        assert reg.status.value == "success"
+
+        login = svc.login("jwt-svc@example.com", "SecurePass123!")
+        assert login.status.value == "success"
+
+        verify = svc.verify(login.token_pair.access_token)
+        assert verify.status.value == "success"
+
+        refresh = svc.refresh(login.token_pair.refresh_token)
+        assert refresh.status.value == "success"
+
+    def test_service_validation_empty_email(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        with pytest.raises(Exception):
+            svc.register("", "SecurePass123!")
+
+    def test_service_validation_empty_password(self):
+        from services.auth.service import AuthService
+
+        svc = AuthService()
+        with pytest.raises(Exception):
+            svc.register("user@example.com", "")

--- a/docs/architecture/0003-auth-service.md
+++ b/docs/architecture/0003-auth-service.md
@@ -1,0 +1,114 @@
+# ADR 0003: Auth Service
+
+## Status
+
+Accepted
+
+## Context
+
+Authentication is a cross-product capability required by every application
+built by Palmshed. Rather than implementing auth independently in each
+product, we need a reusable, provider-agnostic auth service that can be
+shared across products.
+
+Key requirements:
+
+- Provider-agnostic: support multiple auth strategies (JWT, OAuth2, etc.)
+- Product-agnostic: zero coupling to any specific application
+- Minimal dependencies: core auth works with stdlib only
+- Testable: mock provider for development and automated tests
+
+## Decision
+
+Introduce `services.auth` as a new Platform Service following the same
+architecture as the mail service (`services.mail`).
+
+### Architecture
+
+```text
+services/auth/
+├── __init__.py          # Public API re-exports
+├── config.py            # AuthConfig from env (single source of truth)
+├── models.py            # User, TokenPair, AuthResult, AuthStatus
+├── metrics.py           # AuthMetrics (login/register/verify counts)
+├── logging.py           # Structured audit logging
+├── service.py           # AuthService (single public API)
+├── verify.py            # CLI for end-to-end verification
+├── README.md            # Versioning policy and usage guide
+└── providers/
+    ├── __init__.py       # Auto-registration + factory
+    ├── base.py           # AuthProvider ABC
+    ├── registry.py       # ProviderRegistry (register/create/available)
+    ├── mock.py           # MockAuth (in-memory, no dependencies)
+    └── jwt.py            # JWTAuth (HMAC-SHA256, stdlib only)
+```
+
+### Provider interface
+
+```python
+class AuthProvider(ABC):
+    def create_user(self, email: str, password: str, **kwargs) -> AuthResult
+    def authenticate(self, email: str, password: str) -> AuthResult
+    def verify_token(self, token: str) -> AuthResult
+    def refresh_token(self, refresh_token: str) -> AuthResult
+    def revoke_token(self, refresh_token: str) -> None
+```
+
+### AuthService public API
+
+```python
+class AuthService:
+    def register(self, email: str, password: str, **kwargs) -> AuthResult
+    def login(self, email: str, password: str) -> AuthResult
+    def verify(self, token: str) -> AuthResult
+    def refresh(self, refresh_token: str) -> AuthResult
+    def logout(self, refresh_token: str) -> None
+    def health(self) -> AuthHealthStatus
+```
+
+### Configuration
+
+All environment variables are read exclusively in `AuthConfig.from_env()`:
+
+- `AUTH_PROVIDER` — provider name (default: `mock`)
+- `JWT_SECRET` — signing key for JWT tokens
+- `JWT_ALGORITHM` — signing algorithm (default: `HS256`)
+- `ACCESS_TOKEN_EXPIRE_MINUTES` — access token TTL (default: `15`)
+- `REFRESH_TOKEN_EXPIRE_DAYS` — refresh token TTL (default: `7`)
+
+### Mock provider
+
+`MockAuth` stores users and sessions in memory. No credentials or secrets
+required. Used by default in development and tests.
+
+### JWT provider
+
+`JWTAuth` implements self-contained JWT tokens using stdlib (`hmac`,
+`hashlib`, `base64`, `json`). No external JWT library required. Tokens are
+signed with HMAC-SHA256.
+
+### Health integration
+
+The health endpoint instantiates `AuthService` lazily and includes the
+provider name and config validity in the health response.
+
+## Consequences
+
+Positive:
+
+- Products can authenticate users without choosing a provider
+- Mock provider enables isolated testing
+- Consistent architecture across mail and auth services
+- Architecture boundary tests enforce product-agnostic constraints
+
+Negative:
+
+- Initial JWT provider uses basic HMAC; advanced features (RS256, JWKs)
+  require future enhancement
+- No storage persistence in mock provider (in-memory only)
+
+## References
+
+- ADR 0001: Platform Services
+- ADR 0002: Mail Service
+- `services/mail/` — reference implementation


### PR DESCRIPTION
## Summary

Adds the Authentication service as a new Platform Service, following the same provider-agnostic architecture as the mail service.

## Changes

### Auth Service (`services/auth/`)
- **AuthProvider** ABC with `create_user`, `authenticate`, `verify_token`, `refresh_token`, `revoke_token`
- **MockAuth** — in-memory user/session store (default, no credentials needed)
- **JWTAuth** — self-contained JWT tokens using stdlib (`hmac`, `hashlib`, `base64`), supports HS256/HS384/HS512
- **ProviderRegistry** — `register()` / `create()` / `available()` matching `services.mail`
- **AuthConfig** — reads `AUTH_PROVIDER`, `JWT_SECRET`, `JWT_ALGORITHM`, `ACCESS_TOKEN_EXPIRE_MINUTES`, `REFRESH_TOKEN_EXPIRE_DAYS` from env
- **AuthService** public API: `register()`, `login()`, `verify()`, `refresh()`, `logout()`, `health()`
- **AuthResult** with typed `AuthStatus` enum: SUCCESS, FAILED, EXPIRED, INVALID, LOCKED
- **AuthMetrics** — registration/login/verification/refresh/failure counts + durations
- **AuthLogger** — structured audit events per operation
- **verify.py** — CLI for end-to-end smoke testing

### Integration
- Health endpoint (`/api/health`) now includes `auth` status (provider name, config validity)
- ADR 0003 documenting the architecture

### Tests (80 tests)
- Architecture boundary tests: no application imports, config is single env source, providers extend ABC
- Model tests: User, TokenPair, AuthResult, AuthStatus, AuthHealthStatus
- Config tests: defaults, validation, from_env()
- Provider tests: MockAuth and JWTAuth (register, login, verify, refresh, revoke, reset)
- Service tests: full lifecycle through AuthService
- Pre-commit green, all 179 tests pass

## Verification

- 179 tests pass, ruff clean, black formatted
- Architecture boundaries enforced: no Flask/application imports in service
- JWT token tampering and wrong-secret rejection validated
- Both providers tested through AuthService for the full lifecycle
