### PR TITLE
fix: sync uv.lock after version bump in release action

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -62,6 +62,9 @@ runs:
         print(f'Version bumped: {current} → {new}')
         "
       shell: bash
+    - name: Sync uv.lock
+      run: uv lock
+      shell: bash
     - name: Create PR
       id: create-pr
       uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
The release action bumps version in VERSION, __init__.py, and pyproject.toml but never updates uv.lock. This causes a drift between pyproject.toml and uv.lock on the version-bump branch.

Adds a `uv lock` step after the version bump and before the PR is created.