### PR TITLE
fix: install uv before running uv lock in release action

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -14,6 +14,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install uv
+      run: pip install uv
+      shell: bash
     - name: Compute new version
       run: |
         current=$(cat VERSION)


### PR DESCRIPTION
The release action runs `uv lock` to sync `uv.lock` after version bump, but `uv` is not installed in the CI runner environment. Adds `actions/setup-python` and `pip install uv` steps before the bump logic.