### PR TITLE
feat: add storage platform service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ Application
 │
 ├── Platform Services
 │   ├── Mail
-│   ├── Auth (future)
-│   ├── Storage (future)
+│   ├── Auth
+│   ├── Storage
 │   └── Notifications (future)
 │
 └── Infrastructure
@@ -68,8 +68,8 @@ independently of any single application.
 Examples:
 
 - Mail
-- Authentication (future)
-- Storage (future)
+- Authentication
+- Storage
 - Notifications (future)
 
 Platform services:
@@ -155,6 +155,8 @@ Current records:
 
 - `0001-platform-services.md` — introducing the Platform Services layer
 - `0002-mail-service.md` — mail as a reusable platform capability
+- `0003-auth-service.md` — auth as a reusable platform capability
+- `0003-storage-service.md` — storage as a reusable platform capability
 
 ---
 

--- a/backend/palmshed_ai/routes/api.py
+++ b/backend/palmshed_ai/routes/api.py
@@ -302,4 +302,35 @@ def health_check():
         auth_status["error"] = str(exc)
         logging.warning("Auth service health check failed: %s", exc)
 
-    return jsonify({"status": "ok", "mail": mail_status, "auth": auth_status})
+    storage_status = {"provider": "unknown"}
+    try:
+        from services.storage.config import StorageConfig
+        from services.storage.service import StorageService
+
+        storage_config = StorageConfig.from_env()
+        storage_status["provider"] = storage_config.provider
+        storage_status["bucket"] = storage_config.bucket
+        valid, errors = storage_config.is_valid()
+        storage_status["config_valid"] = valid
+        if errors:
+            storage_status["config_errors"] = errors
+        svc = StorageService(config=storage_config)
+        health = svc.health()
+        storage_status["provider"] = health.provider
+        storage_status["config_valid"] = health.config_valid
+        storage_status["bucket"] = health.bucket
+        storage_status["healthy"] = health.healthy
+        if health.config_errors:
+            storage_status["config_errors"] = health.config_errors
+    except Exception as exc:
+        storage_status["error"] = str(exc)
+        logging.warning("Storage service health check failed: %s", exc)
+
+    return jsonify(
+        {
+            "status": "ok",
+            "mail": mail_status,
+            "auth": auth_status,
+            "storage": storage_status,
+        }
+    )

--- a/backend/services/storage/README.md
+++ b/backend/services/storage/README.md
@@ -1,0 +1,67 @@
+# Storage Platform Service
+
+Provider-agnostic storage service for Palmshed products.
+
+## Public API
+
+```python
+from services.storage import StorageService, StorageConfig
+
+config = StorageConfig.from_env()
+svc = StorageService(config=config)
+
+obj = svc.upload("path/to/file.txt", data, content_type="text/plain")
+data = svc.download("path/to/file.txt")
+svc.delete("path/to/file.txt")
+exists = svc.exists("path/to/file.txt")
+meta = svc.metadata("path/to/file.txt")
+objects = svc.list(prefix="path/to/")
+url = svc.signed_url("path/to/file.txt", expires_in_seconds=3600)
+health = svc.health()
+```
+
+## Providers
+
+| Provider | Config | Description |
+|----------|--------|-------------|
+| `mock`   | (default) | In-memory store, no persistence. |
+| `local`  | `STORAGE_BASE_PATH` | Local filesystem storage. |
+| `cloud`  | — | Interface stub. Replace with GCS, S3, R2, or Azure. |
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STORAGE_PROVIDER` | `mock` | Provider name (`mock`, `local`, `cloud`) |
+| `STORAGE_BUCKET` | `alma` | Logical bucket/container name |
+| `STORAGE_BASE_PATH` | — | Filesystem path for local provider |
+| `STORAGE_PUBLIC_URL` | — | Public base URL for serving objects |
+| `MAX_UPLOAD_SIZE_MB` | `50` | Maximum upload size in MB |
+
+## Health
+
+```json
+{
+  "provider": "mock",
+  "config_valid": true,
+  "bucket": "alma",
+  "healthy": true
+}
+```
+
+## Verification CLI
+
+```bash
+python -m services.storage.verify
+```
+
+Uploads, downloads, checksums, deletes, and reports latency for each step.
+
+## Adding a Provider
+
+1. Create `backend/services/storage/providers/gcs.py`
+2. Implement `StorageProvider` ABC
+3. Register in `providers/__init__.py`
+4. Set `STORAGE_PROVIDER=gcs`
+
+No application code changes needed.

--- a/backend/services/storage/__init__.py
+++ b/backend/services/storage/__init__.py
@@ -1,0 +1,26 @@
+from .config import StorageConfig
+from .metrics import StorageMetrics
+from .models import StorageHealth, StorageObject, StorageResult, StorageStatus
+from .service import StorageError, StorageService, StorageValidationError
+from .providers import (
+    ProviderCapabilities,
+    ProviderRegistry,
+    StorageProvider,
+    get_provider,
+)
+
+__all__ = [
+    "StorageConfig",
+    "StorageMetrics",
+    "StorageService",
+    "StorageObject",
+    "StorageResult",
+    "StorageStatus",
+    "StorageError",
+    "StorageValidationError",
+    "StorageHealth",
+    "ProviderCapabilities",
+    "StorageProvider",
+    "ProviderRegistry",
+    "get_provider",
+]

--- a/backend/services/storage/config.py
+++ b/backend/services/storage/config.py
@@ -1,0 +1,35 @@
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class StorageConfig:
+    provider: str = "mock"
+    bucket: str = "alma"
+    base_path: str = ""
+    public_url: str = ""
+    max_upload_size_mb: int = 50
+
+    @staticmethod
+    def from_env() -> "StorageConfig":
+        return StorageConfig(
+            provider=os.getenv("STORAGE_PROVIDER", "mock").lower(),
+            bucket=os.getenv("STORAGE_BUCKET", "alma"),
+            base_path=os.getenv("STORAGE_BASE_PATH", ""),
+            public_url=os.getenv("STORAGE_PUBLIC_URL", ""),
+            max_upload_size_mb=int(os.getenv("MAX_UPLOAD_SIZE_MB", "50")),
+        )
+
+    @property
+    def max_upload_size_bytes(self) -> int:
+        return self.max_upload_size_mb * 1024 * 1024
+
+    def is_valid(self) -> tuple[bool, list[str]]:
+        errors: list[str] = []
+        if self.provider not in ("mock", "local", "cloud"):
+            errors.append(f"Unknown storage provider: {self.provider}")
+        if self.max_upload_size_mb < 1:
+            errors.append("max_upload_size_mb must be >= 1")
+        if self.provider == "local" and not self.base_path:
+            errors.append("STORAGE_BASE_PATH is required for local provider")
+        return (len(errors) == 0, errors)

--- a/backend/services/storage/logging.py
+++ b/backend/services/storage/logging.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Optional
+
+from .models import StorageResult, StorageStatus
+
+logger = logging.getLogger("palmshed.storage.audit")
+
+
+class StorageLogger:
+    def log_result(self, result: StorageResult) -> None:
+        entry = {
+            "object_id": result.object.id if result.object else "",
+            "object_name": result.object.name if result.object else "",
+            "provider": result.provider,
+            "status": result.status.value,
+            "duration_ms": round(result.duration_ms, 2),
+        }
+        if result.error:
+            entry["error"] = result.error
+        logger.info("storage_event", extra=entry)
+
+    def log_operation(
+        self,
+        operation: str,
+        name: str,
+        provider: str,
+        status: StorageStatus,
+        error: Optional[str] = None,
+    ) -> None:
+        entry = {
+            "operation": operation,
+            "object_name": name,
+            "provider": provider,
+            "status": status.value,
+        }
+        if error:
+            entry["error"] = error
+        logger.info("storage_event", extra=entry)

--- a/backend/services/storage/metrics.py
+++ b/backend/services/storage/metrics.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class StorageMetrics:
+    uploads: int = 0
+    downloads: int = 0
+    deletes: int = 0
+    lists: int = 0
+    failures: int = 0
+    _durations: list[float] = field(default_factory=list, repr=False)
+
+    @property
+    def avg_duration_ms(self) -> float:
+        if not self._durations:
+            return 0.0
+        return (sum(self._durations) / len(self._durations)) * 1000
+
+    def record_upload(self) -> None:
+        self.uploads += 1
+
+    def record_download(self) -> None:
+        self.downloads += 1
+
+    def record_delete(self) -> None:
+        self.deletes += 1
+
+    def record_list(self) -> None:
+        self.lists += 1
+
+    def record_failure(self) -> None:
+        self.failures += 1
+
+    def record_duration(self, seconds: float) -> None:
+        self._durations.append(seconds)
+
+    def snapshot(self) -> dict:
+        return {
+            "uploads": self.uploads,
+            "downloads": self.downloads,
+            "deletes": self.deletes,
+            "lists": self.lists,
+            "failures": self.failures,
+            "avg_duration_ms": round(self.avg_duration_ms, 2),
+        }

--- a/backend/services/storage/models.py
+++ b/backend/services/storage/models.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class StorageStatus(Enum):
+    UPLOADED = "uploaded"
+    DOWNLOADED = "downloaded"
+    DELETED = "deleted"
+    EXISTS = "exists"
+    NOT_FOUND = "not_found"
+    FAILED = "failed"
+
+
+@dataclass
+class StorageObject:
+    id: str
+    name: str
+    size: int = 0
+    content_type: str = "application/octet-stream"
+    etag: Optional[str] = None
+    metadata: dict = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    modified_at: datetime = field(default_factory=datetime.utcnow)
+    public_url: Optional[str] = None
+
+
+@dataclass
+class StorageResult:
+    status: StorageStatus
+    object: Optional[StorageObject] = None
+    data: Optional[bytes] = None
+    error: Optional[str] = None
+    provider: str = ""
+    duration_ms: float = 0.0
+
+
+@dataclass
+class StorageHealth:
+    provider: str
+    config_valid: bool
+    config_errors: list[str] = field(default_factory=list)
+    bucket: str = ""
+    healthy: bool = True

--- a/backend/services/storage/providers/__init__.py
+++ b/backend/services/storage/providers/__init__.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from ..config import StorageConfig
+from .base import ProviderCapabilities, StorageProvider
+from .cloud import CloudStorageProvider
+from .local import LocalStorageProvider
+from .mock import MockStorageProvider
+from .registry import ProviderRegistry
+
+ProviderRegistry.register("mock", MockStorageProvider)
+ProviderRegistry.register("local", LocalStorageProvider)
+ProviderRegistry.register("cloud", CloudStorageProvider)
+
+
+def get_provider(config: Optional[StorageConfig] = None) -> StorageProvider:
+    if config is None:
+        config = StorageConfig.from_env()
+    return ProviderRegistry.create(config.provider, config)
+
+
+__all__ = [
+    "StorageProvider",
+    "MockStorageProvider",
+    "LocalStorageProvider",
+    "CloudStorageProvider",
+    "ProviderRegistry",
+    "ProviderCapabilities",
+    "get_provider",
+]

--- a/backend/services/storage/providers/base.py
+++ b/backend/services/storage/providers/base.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..models import StorageResult
+
+
+@dataclass
+class ProviderCapabilities:
+    public_urls: bool = True
+    signed_urls: bool = True
+    multipart_upload: bool = True
+    versioning: bool = True
+    metadata: bool = True
+    streaming: bool = True
+
+
+class StorageProvider(ABC):
+    @abstractmethod
+    def upload(
+        self,
+        name: str,
+        data: bytes,
+        content_type: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> StorageResult: ...
+
+    @abstractmethod
+    def download(self, name: str) -> StorageResult: ...
+
+    @abstractmethod
+    def delete(self, name: str) -> StorageResult: ...
+
+    @abstractmethod
+    def exists(self, name: str) -> StorageResult: ...
+
+    @abstractmethod
+    def metadata(self, name: str) -> StorageResult: ...
+
+    @abstractmethod
+    def list(self, prefix: str = "") -> StorageResult: ...
+
+    @abstractmethod
+    def signed_url(
+        self, name: str, expires_in_seconds: int = 3600
+    ) -> StorageResult: ...
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> ProviderCapabilities: ...

--- a/backend/services/storage/providers/cloud.py
+++ b/backend/services/storage/providers/cloud.py
@@ -1,0 +1,74 @@
+import logging
+
+from ..config import StorageConfig
+from ..models import StorageResult, StorageStatus
+from .base import ProviderCapabilities, StorageProvider
+
+logger = logging.getLogger("palmshed.storage.cloud")
+
+
+class CloudStorageProvider(StorageProvider):
+    def __init__(self, config: StorageConfig) -> None:
+        self._capabilities = ProviderCapabilities(
+            public_urls=True,
+            signed_urls=True,
+            multipart_upload=True,
+            versioning=True,
+            metadata=True,
+            streaming=True,
+        )
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return self._capabilities
+
+    def upload(
+        self, name: str, data: bytes, content_type=None, metadata=None
+    ) -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="CloudStorageProvider is an interface. Use GCS, S3, R2, or Azure.",
+            provider="cloud",
+        )
+
+    def download(self, name: str) -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="CloudStorageProvider is an interface. Use GCS, S3, R2, or Azure.",
+            provider="cloud",
+        )
+
+    def delete(self, name: str) -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="CloudStorageProvider is an interface. Use GCS, S3, R2, or Azure.",
+            provider="cloud",
+        )
+
+    def exists(self, name: str) -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="CloudStorageProvider is an interface. Use GCS, S3, R2, or Azure.",
+            provider="cloud",
+        )
+
+    def metadata(self, name: str) -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="CloudStorageProvider is an interface. Use GCS, S3, R2, or Azure.",
+            provider="cloud",
+        )
+
+    def list(self, prefix: str = "") -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="CloudStorageProvider is an interface. Use GCS, S3, R2, or Azure.",
+            provider="cloud",
+        )
+
+    def signed_url(self, name: str, expires_in_seconds: int = 3600) -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="CloudStorageProvider is an interface. Use GCS, S3, R2, or Azure.",
+            provider="cloud",
+        )

--- a/backend/services/storage/providers/local.py
+++ b/backend/services/storage/providers/local.py
@@ -1,0 +1,194 @@
+import hashlib
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from ..config import StorageConfig
+from ..models import StorageObject, StorageResult, StorageStatus
+from .base import ProviderCapabilities, StorageProvider
+
+logger = logging.getLogger("palmshed.storage.local")
+
+
+class LocalStorageProvider(StorageProvider):
+    def __init__(self, config: StorageConfig) -> None:
+        self._base_path = config.base_path or "/tmp/palmshed_storage"
+        os.makedirs(self._base_path, exist_ok=True)
+        self._capabilities = ProviderCapabilities(
+            public_urls=False,
+            signed_urls=False,
+            multipart_upload=False,
+            versioning=False,
+            metadata=True,
+            streaming=False,
+        )
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return self._capabilities
+
+    def _path(self, name: str) -> str:
+        safe = name.lstrip("/")
+        return os.path.normpath(os.path.join(self._base_path, safe))
+
+    def _ensure_safe(self, name: str) -> None:
+        full = self._path(name)
+        if not full.startswith(os.path.normpath(self._base_path)):
+            raise ValueError(f"Path traversal detected: {name}")
+
+    def upload(
+        self,
+        name: str,
+        data: bytes,
+        content_type: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> StorageResult:
+        self._ensure_safe(name)
+        path = self._path(name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(data)
+        now = datetime.now(timezone.utc)
+        obj = StorageObject(
+            id=str(uuid.uuid4()),
+            name=name,
+            size=len(data),
+            content_type=content_type or "application/octet-stream",
+            etag=hashlib.md5(data).hexdigest(),
+            metadata=metadata or {},
+            created_at=now,
+            modified_at=now,
+        )
+        logger.info("Local upload: name=%s path=%s size=%d", name, path, len(data))
+        return StorageResult(
+            status=StorageStatus.UPLOADED,
+            object=obj,
+            provider="local",
+        )
+
+    def download(self, name: str) -> StorageResult:
+        self._ensure_safe(name)
+        path = self._path(name)
+        if not os.path.exists(path):
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                error=f"Object not found: {name}",
+                provider="local",
+            )
+        with open(path, "rb") as f:
+            data = f.read()
+        stat = os.stat(path)
+        obj = StorageObject(
+            id=name,
+            name=name,
+            size=stat.st_size,
+            content_type="application/octet-stream",
+            etag=hashlib.md5(data).hexdigest(),
+            created_at=datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc),
+            modified_at=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+        )
+        logger.info("Local download: name=%s", name)
+        return StorageResult(
+            status=StorageStatus.DOWNLOADED,
+            object=obj,
+            data=data,
+            provider="local",
+        )
+
+    def delete(self, name: str) -> StorageResult:
+        self._ensure_safe(name)
+        path = self._path(name)
+        if not os.path.exists(path):
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                error=f"Object not found: {name}",
+                provider="local",
+            )
+        size = os.path.getsize(path)
+        obj = StorageObject(
+            id=name,
+            name=name,
+            size=size,
+        )
+        os.remove(path)
+        logger.info("Local delete: name=%s", name)
+        return StorageResult(
+            status=StorageStatus.DELETED,
+            object=obj,
+            provider="local",
+        )
+
+    def exists(self, name: str) -> StorageResult:
+        self._ensure_safe(name)
+        path = self._path(name)
+        if os.path.exists(path):
+            return StorageResult(
+                status=StorageStatus.EXISTS,
+                provider="local",
+            )
+        return StorageResult(
+            status=StorageStatus.NOT_FOUND,
+            provider="local",
+        )
+
+    def metadata(self, name: str) -> StorageResult:
+        self._ensure_safe(name)
+        path = self._path(name)
+        if not os.path.exists(path):
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                error=f"Object not found: {name}",
+                provider="local",
+            )
+        data = b""
+        if os.path.getsize(path) > 0:
+            with open(path, "rb") as f:
+                data = f.read(65536)
+        stat = os.stat(path)
+        obj = StorageObject(
+            id=name,
+            name=name,
+            size=stat.st_size,
+            content_type="application/octet-stream",
+            etag=hashlib.md5(data).hexdigest(),
+            created_at=datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc),
+            modified_at=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+        )
+        return StorageResult(
+            status=StorageStatus.EXISTS,
+            object=obj,
+            provider="local",
+        )
+
+    def list(self, prefix: str = "") -> StorageResult:
+        base = self._base_path
+        if not os.path.exists(base):
+            return StorageResult(
+                status=StorageStatus.EXISTS,
+                data=b"[]",
+                provider="local",
+            )
+        names = []
+        for root, _dirs, files in os.walk(base):
+            for f in files:
+                full = os.path.join(root, f)
+                rel = os.path.relpath(full, base)
+                if rel.startswith(prefix):
+                    names.append(rel)
+        logger.info("Local list: prefix=%s count=%d", prefix, len(names))
+        import json
+
+        return StorageResult(
+            status=StorageStatus.EXISTS,
+            data=json.dumps(names).encode("utf-8"),
+            provider="local",
+        )
+
+    def signed_url(self, name: str, expires_in_seconds: int = 3600) -> StorageResult:
+        return StorageResult(
+            status=StorageStatus.FAILED,
+            error="Local provider does not support signed URLs",
+            provider="local",
+        )

--- a/backend/services/storage/providers/mock.py
+++ b/backend/services/storage/providers/mock.py
@@ -1,0 +1,143 @@
+import hashlib
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from ..config import StorageConfig
+from ..models import StorageObject, StorageResult, StorageStatus
+from .base import ProviderCapabilities, StorageProvider
+
+logger = logging.getLogger("palmshed.storage.mock")
+
+
+class MockStorageProvider(StorageProvider):
+    def __init__(self, config: Optional[StorageConfig] = None) -> None:
+        self._store: dict[str, tuple[StorageObject, bytes]] = {}
+        self._capabilities = ProviderCapabilities(
+            public_urls=True,
+            signed_urls=True,
+            multipart_upload=True,
+            versioning=True,
+            metadata=True,
+            streaming=True,
+        )
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return self._capabilities
+
+    def upload(
+        self,
+        name: str,
+        data: bytes,
+        content_type: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> StorageResult:
+        obj = StorageObject(
+            id=str(uuid.uuid4()),
+            name=name,
+            size=len(data),
+            content_type=content_type or "application/octet-stream",
+            etag=hashlib.md5(data).hexdigest(),
+            metadata=metadata or {},
+            created_at=datetime.now(timezone.utc),
+            modified_at=datetime.now(timezone.utc),
+            public_url=f"/mock/{name}",
+        )
+        self._store[name] = (obj, data)
+        logger.info("Mock upload: name=%s size=%d", name, len(data))
+        return StorageResult(
+            status=StorageStatus.UPLOADED,
+            object=obj,
+            provider="mock",
+        )
+
+    def download(self, name: str) -> StorageResult:
+        entry = self._store.get(name)
+        if not entry:
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                error=f"Object not found: {name}",
+                provider="mock",
+            )
+        obj, data = entry
+        logger.info("Mock download: name=%s", name)
+        return StorageResult(
+            status=StorageStatus.DOWNLOADED,
+            object=obj,
+            data=data,
+            provider="mock",
+        )
+
+    def delete(self, name: str) -> StorageResult:
+        entry = self._store.pop(name, None)
+        if not entry:
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                error=f"Object not found: {name}",
+                provider="mock",
+            )
+        logger.info("Mock delete: name=%s", name)
+        return StorageResult(
+            status=StorageStatus.DELETED,
+            object=entry[0],
+            provider="mock",
+        )
+
+    def exists(self, name: str) -> StorageResult:
+        entry = self._store.get(name)
+        if not entry:
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                provider="mock",
+            )
+        return StorageResult(
+            status=StorageStatus.EXISTS,
+            object=entry[0],
+            provider="mock",
+        )
+
+    def metadata(self, name: str) -> StorageResult:
+        entry = self._store.get(name)
+        if not entry:
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                error=f"Object not found: {name}",
+                provider="mock",
+            )
+        return StorageResult(
+            status=StorageStatus.EXISTS,
+            object=entry[0],
+            provider="mock",
+        )
+
+    def list(self, prefix: str = "") -> StorageResult:
+        matching = [
+            obj for name, (obj, _) in self._store.items() if name.startswith(prefix)
+        ]
+        logger.info("Mock list: prefix=%s count=%d", prefix, len(matching))
+        import json
+
+        return StorageResult(
+            status=StorageStatus.EXISTS,
+            data=json.dumps([o.name for o in matching]).encode("utf-8"),
+            provider="mock",
+        )
+
+    def signed_url(self, name: str, expires_in_seconds: int = 3600) -> StorageResult:
+        entry = self._store.get(name)
+        if not entry:
+            return StorageResult(
+                status=StorageStatus.NOT_FOUND,
+                error=f"Object not found: {name}",
+                provider="mock",
+            )
+        return StorageResult(
+            status=StorageStatus.EXISTS,
+            object=entry[0],
+            provider="mock",
+        )
+
+    def reset(self) -> None:
+        self._store.clear()

--- a/backend/services/storage/providers/registry.py
+++ b/backend/services/storage/providers/registry.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from ..config import StorageConfig
+from .base import StorageProvider
+
+
+class ProviderRegistry:
+    _providers: dict[str, type[StorageProvider]] = {}
+
+    @classmethod
+    def register(cls, name: str, provider_cls: type[StorageProvider]) -> None:
+        cls._providers[name] = provider_cls
+
+    @classmethod
+    def create(cls, name: str, config: StorageConfig) -> StorageProvider:
+        provider_cls = cls._providers.get(name)
+        if not provider_cls:
+            registered = ", ".join(cls.available())
+            raise ValueError(
+                f"Unknown storage provider '{name}'. Registered: {registered}"
+            )
+        return provider_cls(config)
+
+    @classmethod
+    def available(cls) -> list[str]:
+        return list(cls._providers.keys())
+
+    @classmethod
+    def get(cls, name: str) -> Optional[type[StorageProvider]]:
+        return cls._providers.get(name)

--- a/backend/services/storage/service.py
+++ b/backend/services/storage/service.py
@@ -1,0 +1,182 @@
+import time
+import uuid
+from typing import Optional
+
+from .config import StorageConfig
+from .logging import StorageLogger
+from .metrics import StorageMetrics
+from .models import StorageHealth, StorageObject, StorageStatus
+from .providers import StorageProvider, get_provider
+
+
+class StorageError(Exception):
+    pass
+
+
+class StorageValidationError(StorageError):
+    pass
+
+
+class StorageService:
+    def __init__(
+        self,
+        config: Optional[StorageConfig] = None,
+        provider: Optional[StorageProvider] = None,
+        logger: Optional[StorageLogger] = None,
+        metrics: Optional[StorageMetrics] = None,
+    ) -> None:
+        self.config = config or StorageConfig.from_env()
+        self.provider = provider or get_provider(self.config)
+        self.logger = logger or StorageLogger()
+        self.metrics = metrics or StorageMetrics()
+
+    def upload(
+        self,
+        name: str,
+        data: bytes,
+        content_type: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> StorageObject:
+        self._validate_upload(name, data)
+
+        t0 = time.monotonic()
+        result = self.provider.upload(
+            name=name,
+            data=data,
+            content_type=content_type,
+            metadata=metadata,
+        )
+        elapsed = time.monotonic() - t0
+        result.duration_ms = elapsed * 1000
+        self.metrics.record_duration(elapsed)
+
+        if result.status == StorageStatus.FAILED:
+            self.metrics.record_failure()
+            self.logger.log_result(result)
+            raise StorageError(result.error or "upload failed")
+
+        self.metrics.record_upload()
+        self.logger.log_result(result)
+        return result.object
+
+    def download(self, name: str) -> tuple[StorageObject, bytes]:
+        t0 = time.monotonic()
+        result = self.provider.download(name)
+        elapsed = time.monotonic() - t0
+        result.duration_ms = elapsed * 1000
+        self.metrics.record_duration(elapsed)
+
+        if result.status == StorageStatus.NOT_FOUND:
+            self.metrics.record_failure()
+            raise StorageError(f"Object not found: {name}")
+
+        if result.status == StorageStatus.FAILED:
+            self.metrics.record_failure()
+            self.logger.log_result(result)
+            raise StorageError(result.error or "download failed")
+
+        self.metrics.record_download()
+        self.logger.log_result(result)
+        return result.object, result.data
+
+    def delete(self, name: str) -> StorageObject:
+        t0 = time.monotonic()
+        result = self.provider.delete(name)
+        elapsed = time.monotonic() - t0
+        result.duration_ms = elapsed * 1000
+        self.metrics.record_duration(elapsed)
+
+        if result.status == StorageStatus.NOT_FOUND:
+            raise StorageError(f"Object not found: {name}")
+
+        if result.status == StorageStatus.FAILED:
+            self.metrics.record_failure()
+            self.logger.log_result(result)
+            raise StorageError(result.error or "delete failed")
+
+        self.metrics.record_delete()
+        self.logger.log_result(result)
+        return result.object
+
+    def exists(self, name: str) -> bool:
+        t0 = time.monotonic()
+        result = self.provider.exists(name)
+        elapsed = time.monotonic() - t0
+        self.metrics.record_duration(elapsed)
+        return result.status == StorageStatus.EXISTS
+
+    def metadata(self, name: str) -> StorageObject:
+        t0 = time.monotonic()
+        result = self.provider.metadata(name)
+        elapsed = time.monotonic() - t0
+        result.duration_ms = elapsed * 1000
+        self.metrics.record_duration(elapsed)
+
+        if result.status == StorageStatus.NOT_FOUND:
+            raise StorageError(f"Object not found: {name}")
+
+        if result.status == StorageStatus.FAILED:
+            self.metrics.record_failure()
+            raise StorageError(result.error or "metadata fetch failed")
+
+        return result.object
+
+    def list(self, prefix: str = "") -> list[str]:
+        t0 = time.monotonic()
+        result = self.provider.list(prefix)
+        elapsed = time.monotonic() - t0
+        self.metrics.record_duration(elapsed)
+
+        if result.status == StorageStatus.FAILED:
+            self.metrics.record_failure()
+            raise StorageError(result.error or "list failed")
+
+        self.metrics.record_list()
+        if result.data:
+            import json
+
+            return json.loads(result.data.decode("utf-8"))
+        return []
+
+    def signed_url(self, name: str, expires_in_seconds: int = 3600) -> str:
+        t0 = time.monotonic()
+        result = self.provider.signed_url(name, expires_in_seconds)
+        elapsed = time.monotonic() - t0
+        self.metrics.record_duration(elapsed)
+
+        if result.status == StorageStatus.NOT_FOUND:
+            raise StorageError(f"Object not found: {name}")
+
+        if result.status == StorageStatus.FAILED:
+            raise StorageError(result.error or "signed URL not available")
+
+        return result.object.public_url or ""
+
+    def health(self) -> StorageHealth:
+        valid, errors = self.config.is_valid()
+        try:
+            test_name = f"__health_check_{uuid.uuid4().hex[:8]}"
+            self.provider.upload(test_name, b"health")
+            self.provider.delete(test_name)
+            healthy = True
+        except Exception:
+            healthy = False
+
+        return StorageHealth(
+            provider=self.config.provider,
+            config_valid=valid,
+            config_errors=errors,
+            bucket=self.config.bucket,
+            healthy=healthy,
+        )
+
+    def _validate_upload(self, name: str, data: bytes) -> None:
+        if not name:
+            raise StorageValidationError("Object name is required")
+        if len(data) == 0:
+            raise StorageValidationError("Cannot upload empty data")
+        if len(data) > self.config.max_upload_size_bytes:
+            raise StorageValidationError(
+                f"Data too large ({len(data)} bytes); "
+                f"max is {self.config.max_upload_size_bytes}"
+            )

--- a/backend/services/storage/verify.py
+++ b/backend/services/storage/verify.py
@@ -1,0 +1,140 @@
+import argparse
+import hashlib
+import sys
+import time
+import uuid
+
+from .config import StorageConfig
+from .service import StorageService, StorageError
+
+
+def verify(args: argparse.Namespace) -> int:
+    config = StorageConfig.from_env()
+    provider = config.provider
+
+    valid, errors = config.is_valid()
+    if not valid:
+        for e in errors:
+            print(f"CONFIG ERROR: {e}")
+        return 1
+
+    print(f"Provider:     {provider}")
+    print(f"Bucket:       {config.bucket}")
+    print()
+
+    if provider == "mock":
+        print("WARNING: STORAGE_PROVIDER=mock — no real storage.")
+        print("Set STORAGE_PROVIDER=local and STORAGE_BASE_PATH to test local storage.")
+        print()
+
+    try:
+        svc = StorageService(config=config)
+    except Exception as exc:
+        print(f"ERROR: Failed to initialize StorageService: {exc}")
+        return 1
+
+    test_name = f"__verify_test_{uuid.uuid4().hex[:12]}"
+    test_data = b"Hello, Storage! This is a verification test."
+    original_checksum = hashlib.sha256(test_data).hexdigest()
+
+    print("=== Upload ===")
+    t0 = time.monotonic()
+    try:
+        obj = svc.upload(test_name, test_data, content_type="text/plain")
+    except StorageError as exc:
+        print(f"FAILED: {exc}")
+        return 1
+    elapsed = (time.monotonic() - t0) * 1000
+    print(f"Name:     {obj.name}")
+    print(f"Size:     {obj.size} bytes")
+    print(f"ETag:     {obj.etag}")
+    print(f"Duration: {elapsed:.1f} ms")
+    print()
+
+    print("=== Exists ===")
+    t0 = time.monotonic()
+    exists = svc.exists(test_name)
+    elapsed = (time.monotonic() - t0) * 1000
+    print(f"Exists:   {exists}")
+    print(f"Duration: {elapsed:.1f} ms")
+    if not exists:
+        print("FAILED: Object should exist after upload")
+        return 1
+    print()
+
+    print("=== Download ===")
+    t0 = time.monotonic()
+    try:
+        dl_obj, dl_data = svc.download(test_name)
+    except StorageError as exc:
+        print(f"FAILED: {exc}")
+        return 1
+    elapsed = (time.monotonic() - t0) * 1000
+    dl_checksum = hashlib.sha256(dl_data).hexdigest()
+    checksum_match = original_checksum == dl_checksum
+    print(f"Size:     {len(dl_data)} bytes")
+    print(f"Checksum: {'MATCH' if checksum_match else 'MISMATCH'}")
+    print(f"Duration: {elapsed:.1f} ms")
+    if not checksum_match:
+        print("FAILED: Downloaded data checksum does not match")
+        return 1
+    print()
+
+    print("=== Metadata ===")
+    t0 = time.monotonic()
+    try:
+        meta = svc.metadata(test_name)
+    except StorageError as exc:
+        print(f"FAILED: {exc}")
+        return 1
+    elapsed = (time.monotonic() - t0) * 1000
+    print(f"Name:     {meta.name}")
+    print(f"Size:     {meta.size} bytes")
+    print(f"Duration: {elapsed:.1f} ms")
+    print()
+
+    print("=== Delete ===")
+    t0 = time.monotonic()
+    try:
+        svc.delete(test_name)
+    except StorageError as exc:
+        print(f"FAILED: {exc}")
+        return 1
+    elapsed = (time.monotonic() - t0) * 1000
+    print(f"Duration: {elapsed:.1f} ms")
+    print()
+
+    print("=== Verify Deletion ===")
+    exists = svc.exists(test_name)
+    print(f"Exists:   {exists}")
+    if exists:
+        print("FAILED: Object should not exist after deletion")
+        return 1
+    print()
+
+    print("=== Health ===")
+    health = svc.health()
+    print(f"Provider:     {health.provider}")
+    print(f"Config valid: {health.config_valid}")
+    print(f"Bucket:       {health.bucket}")
+    print(f"Healthy:      {health.healthy}")
+    print()
+
+    print("All storage checks passed.")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify storage service end-to-end",
+    )
+    parser.add_argument("--name", help="Object name to use (default: auto-generated)")
+    parser.add_argument("--file", help="File to upload (default: inline test data)")
+
+    args = parser.parse_args()
+
+    sys.exit(verify(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,0 +1,629 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import os
+import tempfile
+
+import pytest
+
+from services.storage import (
+    StorageConfig,
+    StorageService,
+    StorageObject,
+    StorageResult,
+    StorageStatus,
+    StorageMetrics,
+    StorageError,
+    StorageValidationError,
+    StorageHealth,
+    ProviderCapabilities,
+    ProviderRegistry,
+)
+from services.storage.providers import (
+    MockStorageProvider,
+    LocalStorageProvider,
+    CloudStorageProvider,
+    get_provider,
+)
+
+
+class TestStorageModels:
+    def test_storage_object_defaults(self):
+        obj = StorageObject(id="1", name="test.txt")
+        assert obj.size == 0
+        assert obj.content_type == "application/octet-stream"
+        assert obj.metadata == {}
+
+    def test_storage_object_with_fields(self):
+        obj = StorageObject(
+            id="1",
+            name="test.txt",
+            size=100,
+            content_type="text/plain",
+            etag="abc123",
+            metadata={"key": "value"},
+        )
+        assert obj.size == 100
+        assert obj.content_type == "text/plain"
+        assert obj.etag == "abc123"
+
+    def test_storage_result_creation(self):
+        result = StorageResult(
+            status=StorageStatus.UPLOADED,
+            provider="mock",
+        )
+        assert result.status == StorageStatus.UPLOADED
+
+    def test_storage_result_with_object(self):
+        obj = StorageObject(id="1", name="test.txt")
+        result = StorageResult(
+            status=StorageStatus.UPLOADED,
+            object=obj,
+            provider="mock",
+        )
+        assert result.object.name == "test.txt"
+
+    def test_storage_result_with_data(self):
+        result = StorageResult(
+            status=StorageStatus.DOWNLOADED,
+            data=b"hello",
+            provider="mock",
+        )
+        assert result.data == b"hello"
+
+    def test_storage_health(self):
+        h = StorageHealth(
+            provider="mock",
+            config_valid=True,
+            bucket="alma",
+            healthy=True,
+        )
+        assert h.provider == "mock"
+        assert h.config_valid
+        assert h.healthy
+
+    def test_storage_health_with_errors(self):
+        h = StorageHealth(
+            provider="mock",
+            config_valid=False,
+            config_errors=["bad config"],
+            healthy=False,
+        )
+        assert not h.config_valid
+        assert "bad config" in h.config_errors
+        assert not h.healthy
+
+    def test_storage_status_values(self):
+        assert StorageStatus.UPLOADED.value == "uploaded"
+        assert StorageStatus.DOWNLOADED.value == "downloaded"
+        assert StorageStatus.DELETED.value == "deleted"
+        assert StorageStatus.EXISTS.value == "exists"
+        assert StorageStatus.NOT_FOUND.value == "not_found"
+        assert StorageStatus.FAILED.value == "failed"
+
+
+class TestStorageConfig:
+    def test_default_config(self):
+        config = StorageConfig()
+        assert config.provider == "mock"
+        assert config.bucket == "alma"
+        assert config.max_upload_size_mb == 50
+        assert config.max_upload_size_bytes == 50 * 1024 * 1024
+
+    def test_config_validation_valid(self):
+        config = StorageConfig()
+        valid, errors = config.is_valid()
+        assert valid
+        assert errors == []
+
+    def test_config_validation_invalid_provider(self):
+        config = StorageConfig(provider="nonexistent")
+        valid, errors = config.is_valid()
+        assert not valid
+        assert any("provider" in e.lower() for e in errors)
+
+    def test_config_validation_invalid_max_size(self):
+        config = StorageConfig(max_upload_size_mb=0)
+        valid, errors = config.is_valid()
+        assert not valid
+        assert any("max_upload_size_mb" in e for e in errors)
+
+    def test_config_validation_local_no_base_path(self):
+        config = StorageConfig(provider="local")
+        valid, errors = config.is_valid()
+        assert not valid
+        assert any("base_path" in e.lower() for e in errors)
+
+    def test_config_validation_local_with_base_path(self):
+        config = StorageConfig(provider="local", base_path="/tmp/test")
+        valid, errors = config.is_valid()
+        assert valid
+
+    def test_from_env_defaults(self, monkeypatch):
+        monkeypatch.delenv("STORAGE_PROVIDER", raising=False)
+        config = StorageConfig.from_env()
+        assert config.provider == "mock"
+
+    def test_from_env_override(self, monkeypatch):
+        monkeypatch.setenv("STORAGE_PROVIDER", "local")
+        monkeypatch.setenv("STORAGE_BASE_PATH", "/tmp/test")
+        config = StorageConfig.from_env()
+        assert config.provider == "local"
+        assert config.base_path == "/tmp/test"
+
+
+class TestStorageMetrics:
+    def test_initial_state(self):
+        m = StorageMetrics()
+        assert m.uploads == 0
+        assert m.downloads == 0
+        assert m.deletes == 0
+        assert m.lists == 0
+        assert m.failures == 0
+        assert m.avg_duration_ms == 0.0
+
+    def test_record_counts(self):
+        m = StorageMetrics()
+        m.record_upload()
+        m.record_download()
+        m.record_delete()
+        m.record_list()
+        m.record_failure()
+        snap = m.snapshot()
+        assert snap["uploads"] == 1
+        assert snap["downloads"] == 1
+        assert snap["deletes"] == 1
+        assert snap["lists"] == 1
+        assert snap["failures"] == 1
+
+    def test_average_duration(self):
+        m = StorageMetrics()
+        m.record_duration(0.1)
+        m.record_duration(0.2)
+        assert m.avg_duration_ms == pytest.approx(150.0, abs=0.001)
+
+    def test_snapshot(self):
+        m = StorageMetrics()
+        m.record_upload()
+        snap = m.snapshot()
+        assert isinstance(snap, dict)
+        assert "uploads" in snap
+        assert "avg_duration_ms" in snap
+
+
+class TestProviderCapabilities:
+    def test_default_capabilities(self):
+        caps = ProviderCapabilities()
+        assert caps.public_urls
+        assert caps.signed_urls
+        assert caps.multipart_upload
+        assert caps.versioning
+        assert caps.metadata
+        assert caps.streaming
+
+
+class TestMockStorageProvider:
+    @pytest.fixture
+    def provider(self):
+        return MockStorageProvider()
+
+    def test_upload_returns_result(self, provider):
+        result = provider.upload("test.txt", b"hello")
+        assert result.status == StorageStatus.UPLOADED
+        assert result.object.name == "test.txt"
+
+    def test_upload_sets_size_and_etag(self, provider):
+        data = b"hello world"
+        result = provider.upload("test.txt", data)
+        assert result.object.size == len(data)
+        assert result.object.etag == hashlib.md5(data).hexdigest()
+
+    def test_upload_with_content_type(self, provider):
+        result = provider.upload("test.txt", b"hello", content_type="text/plain")
+        assert result.object.content_type == "text/plain"
+
+    def test_upload_with_metadata(self, provider):
+        result = provider.upload("test.txt", b"hello", metadata={"author": "test"})
+        assert result.object.metadata["author"] == "test"
+
+    def test_download_existing(self, provider):
+        provider.upload("test.txt", b"hello")
+        result = provider.download("test.txt")
+        assert result.status == StorageStatus.DOWNLOADED
+        assert result.data == b"hello"
+
+    def test_download_nonexistent(self, provider):
+        result = provider.download("nonexistent.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_delete_existing(self, provider):
+        provider.upload("test.txt", b"hello")
+        result = provider.delete("test.txt")
+        assert result.status == StorageStatus.DELETED
+
+    def test_delete_nonexistent(self, provider):
+        result = provider.delete("nonexistent.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_exists_existing(self, provider):
+        provider.upload("test.txt", b"hello")
+        result = provider.exists("test.txt")
+        assert result.status == StorageStatus.EXISTS
+
+    def test_exists_nonexistent(self, provider):
+        result = provider.exists("nonexistent.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_metadata_existing(self, provider):
+        provider.upload("test.txt", b"hello")
+        result = provider.metadata("test.txt")
+        assert result.status == StorageStatus.EXISTS
+        assert result.object.name == "test.txt"
+
+    def test_metadata_nonexistent(self, provider):
+        result = provider.metadata("nonexistent.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_list_with_prefix(self, provider):
+        provider.upload("a/file1.txt", b"1")
+        provider.upload("a/file2.txt", b"2")
+        provider.upload("b/file3.txt", b"3")
+        result = provider.list("a/")
+        assert result.status == StorageStatus.EXISTS
+        names = eval(result.data.decode())
+        assert len(names) == 2
+        assert "a/file1.txt" in names
+
+    def test_list_empty_prefix(self, provider):
+        provider.upload("a.txt", b"1")
+        provider.upload("b.txt", b"2")
+        result = provider.list("")
+        assert result.status == StorageStatus.EXISTS
+        names = eval(result.data.decode())
+        assert len(names) == 2
+
+    def test_signed_url_existing(self, provider):
+        provider.upload("test.txt", b"hello")
+        result = provider.signed_url("test.txt")
+        assert result.status == StorageStatus.EXISTS
+
+    def test_signed_url_nonexistent(self, provider):
+        result = provider.signed_url("nonexistent.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_capabilities(self, provider):
+        caps = provider.capabilities
+        assert caps.public_urls
+        assert caps.signed_urls
+        assert caps.streaming
+
+    def test_reset(self, provider):
+        provider.upload("test.txt", b"hello")
+        provider.reset()
+        result = provider.exists("test.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_upload_after_reset(self, provider):
+        provider.upload("test.txt", b"hello")
+        provider.reset()
+        result = provider.upload("test.txt", b"world")
+        assert result.status == StorageStatus.UPLOADED
+
+
+class TestLocalStorageProvider:
+    @pytest.fixture
+    def tmpdir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    @pytest.fixture
+    def provider(self, tmpdir):
+        config = StorageConfig(provider="local", base_path=tmpdir)
+        return LocalStorageProvider(config)
+
+    def test_upload_and_download(self, provider):
+        result = provider.upload("test.txt", b"hello")
+        assert result.status == StorageStatus.UPLOADED
+        dl = provider.download("test.txt")
+        assert dl.status == StorageStatus.DOWNLOADED
+        assert dl.data == b"hello"
+
+    def test_upload_nested_path(self, provider):
+        result = provider.upload("dir/subdir/test.txt", b"nested")
+        assert result.status == StorageStatus.UPLOADED
+        dl = provider.download("dir/subdir/test.txt")
+        assert dl.data == b"nested"
+
+    def test_upload_rejects_path_traversal(self, provider):
+        with pytest.raises(ValueError, match="Path traversal"):
+            provider.upload("../outside.txt", b"bad")
+
+    def test_download_nonexistent(self, provider):
+        result = provider.download("nonexistent.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_delete_existing(self, provider):
+        provider.upload("test.txt", b"hello")
+        result = provider.delete("test.txt")
+        assert result.status == StorageStatus.DELETED
+
+    def test_delete_nonexistent(self, provider):
+        result = provider.delete("nonexistent.txt")
+        assert result.status == StorageStatus.NOT_FOUND
+
+    def test_exists(self, provider):
+        provider.upload("test.txt", b"hello")
+        assert provider.exists("test.txt").status == StorageStatus.EXISTS
+        assert provider.exists("nope.txt").status == StorageStatus.NOT_FOUND
+
+    def test_metadata(self, provider):
+        provider.upload("test.txt", b"hello")
+        result = provider.metadata("test.txt")
+        assert result.status == StorageStatus.EXISTS
+        assert result.object.size == 5
+
+    def test_list(self, provider):
+        provider.upload("a/1.txt", b"1")
+        provider.upload("a/2.txt", b"2")
+        provider.upload("b/3.txt", b"3")
+        result = provider.list("a/")
+        assert result.status == StorageStatus.EXISTS
+        names = eval(result.data.decode())
+        assert len(names) == 2
+
+    def test_signed_url_unsupported(self, provider):
+        result = provider.signed_url("test.txt")
+        assert result.status == StorageStatus.FAILED
+
+    def test_capabilities(self, provider):
+        caps = provider.capabilities
+        assert not caps.public_urls
+        assert not caps.signed_urls
+        assert caps.metadata
+
+
+class TestCloudStorageProvider:
+    @pytest.fixture
+    def provider(self):
+        config = StorageConfig(provider="cloud")
+        return CloudStorageProvider(config)
+
+    def test_all_operations_fail(self, provider):
+        assert provider.upload("x", b"data").status == StorageStatus.FAILED
+        assert provider.download("x").status == StorageStatus.FAILED
+        assert provider.delete("x").status == StorageStatus.FAILED
+        assert provider.exists("x").status == StorageStatus.FAILED
+        assert provider.metadata("x").status == StorageStatus.FAILED
+        assert provider.list().status == StorageStatus.FAILED
+        assert provider.signed_url("x").status == StorageStatus.FAILED
+
+    def test_capabilities(self, provider):
+        caps = provider.capabilities
+        assert caps.public_urls
+        assert caps.signed_urls
+        assert caps.multipart_upload
+
+    def test_error_message(self, provider):
+        result = provider.upload("x", b"data")
+        assert "interface" in result.error.lower()
+
+
+class TestProviderRegistry:
+    def test_register_and_create(self):
+        ProviderRegistry.register("test_provider", MockStorageProvider)
+        config = StorageConfig(provider="test_provider")
+        provider = ProviderRegistry.create("test_provider", config)
+        assert isinstance(provider, MockStorageProvider)
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown storage provider"):
+            ProviderRegistry.create("does_not_exist", StorageConfig())
+
+    def test_available_includes_registered(self):
+        available = ProviderRegistry.available()
+        assert "mock" in available
+        assert "local" in available
+        assert "cloud" in available
+
+    def test_get_returns_none_for_unknown(self):
+        assert ProviderRegistry.get("nonexistent") is None
+
+    def test_get_returns_class(self):
+        cls = ProviderRegistry.get("mock")
+        assert cls is MockStorageProvider
+
+
+class TestGetProvider:
+    def test_get_provider_default(self):
+        provider = get_provider()
+        assert isinstance(provider, MockStorageProvider)
+
+    def test_get_provider_with_config(self):
+        config = StorageConfig(provider="local", base_path="/tmp/test")
+        provider = get_provider(config)
+        assert isinstance(provider, LocalStorageProvider)
+
+    def test_get_provider_unknown(self):
+        config = StorageConfig(provider="nope")
+        with pytest.raises(ValueError, match="Unknown storage provider"):
+            get_provider(config)
+
+
+class TestStorageService:
+    def test_upload_returns_object(self):
+        svc = StorageService()
+        obj = svc.upload("test.txt", b"hello")
+        assert isinstance(obj, StorageObject)
+        assert obj.name == "test.txt"
+        assert obj.size == 5
+
+    def test_upload_with_content_type(self):
+        svc = StorageService()
+        obj = svc.upload("test.txt", b"hello", content_type="text/plain")
+        assert obj.content_type == "text/plain"
+
+    def test_upload_with_metadata(self):
+        svc = StorageService()
+        obj = svc.upload("test.txt", b"hello", metadata={"key": "val"})
+        assert obj.metadata["key"] == "val"
+
+    def test_download_returns_data(self):
+        svc = StorageService()
+        svc.upload("test.txt", b"hello")
+        obj, data = svc.download("test.txt")
+        assert data == b"hello"
+        assert obj.name == "test.txt"
+
+    def test_download_nonexistent_raises(self):
+        svc = StorageService()
+        with pytest.raises(StorageError, match="not found"):
+            svc.download("nonexistent.txt")
+
+    def test_delete(self):
+        svc = StorageService()
+        svc.upload("test.txt", b"hello")
+        obj = svc.delete("test.txt")
+        assert obj.name == "test.txt"
+
+    def test_delete_nonexistent_raises(self):
+        svc = StorageService()
+        with pytest.raises(StorageError, match="not found"):
+            svc.delete("nonexistent.txt")
+
+    def test_exists_uploaded(self):
+        svc = StorageService()
+        svc.upload("test.txt", b"hello")
+        assert svc.exists("test.txt")
+
+    def test_exists_missing(self):
+        svc = StorageService()
+        assert not svc.exists("nope.txt")
+
+    def test_exists_after_delete(self):
+        svc = StorageService()
+        svc.upload("test.txt", b"hello")
+        svc.delete("test.txt")
+        assert not svc.exists("test.txt")
+
+    def test_metadata(self):
+        svc = StorageService()
+        svc.upload("test.txt", b"hello")
+        obj = svc.metadata("test.txt")
+        assert obj.size == 5
+
+    def test_list(self):
+        svc = StorageService()
+        svc.upload("a/1.txt", b"1")
+        svc.upload("a/2.txt", b"2")
+        names = svc.list("a/")
+        assert len(names) == 2
+        assert "a/1.txt" in names
+
+    def test_list_empty(self):
+        svc = StorageService()
+        names = svc.list("nonexistent/")
+        assert names == []
+
+    def test_signed_url(self):
+        svc = StorageService()
+        svc.upload("test.txt", b"hello")
+        url = svc.signed_url("test.txt")
+        assert url == "/mock/test.txt"
+
+    def test_signed_url_nonexistent_raises(self):
+        svc = StorageService()
+        with pytest.raises(StorageError, match="not found"):
+            svc.signed_url("nonexistent.txt")
+
+
+class TestStorageValidation:
+    def test_rejects_empty_name(self):
+        svc = StorageService()
+        with pytest.raises(StorageValidationError, match="name is required"):
+            svc.upload("", b"data")
+
+    def test_rejects_empty_data(self):
+        svc = StorageService()
+        with pytest.raises(StorageValidationError, match="empty"):
+            svc.upload("test.txt", b"")
+
+    def test_rejects_too_large_data(self):
+        config = StorageConfig(max_upload_size_mb=1)
+        svc = StorageService(config=config)
+        with pytest.raises(StorageValidationError, match="too large"):
+            svc.upload("test.txt", b"x" * (2 * 1024 * 1024))
+
+
+class TestStorageServiceHealth:
+    def test_health_returns_status(self):
+        svc = StorageService()
+        h = svc.health()
+        assert isinstance(h, StorageHealth)
+        assert h.provider == "mock"
+        assert h.config_valid
+        assert h.healthy
+
+    def test_health_with_invalid_config(self):
+        config = StorageConfig(provider="local")
+        svc = StorageService(config=config)
+        h = svc.health()
+        assert not h.config_valid
+        assert len(h.config_errors) > 0
+
+    def test_health_has_bucket(self):
+        svc = StorageService()
+        h = svc.health()
+        assert h.bucket == "alma"
+
+    def test_health_with_local_provider(self):
+        with tempfile.TemporaryDirectory() as d:
+            config = StorageConfig(provider="local", base_path=d)
+            svc = StorageService(config=config)
+            h = svc.health()
+            assert h.healthy
+
+
+class TestStorageArchitectureBoundaries:
+    def test_no_application_imports(self):
+        import services.storage
+
+        storage_dir = os.path.dirname(services.storage.__file__)
+        for root, _dirs, files in os.walk(storage_dir):
+            for f in files:
+                if f.endswith(".py") and f != "__init__.py":
+                    filepath = os.path.join(root, f)
+                    with open(filepath) as fh:
+                        content = fh.read()
+                    assert (
+                        "palmshed_ai" not in content
+                    ), f"Application import found in {filepath}"
+
+    def test_config_is_single_env_source(self):
+        config = StorageConfig.from_env()
+        assert hasattr(config, "from_env")
+        assert hasattr(config, "is_valid")
+
+    def test_mock_provider_extends_base(self):
+        from services.storage.providers import StorageProvider as SP
+
+        assert issubclass(MockStorageProvider, SP)
+
+    def test_local_provider_extends_base(self):
+        from services.storage.providers import StorageProvider as SP
+
+        assert issubclass(LocalStorageProvider, SP)
+
+    def test_cloud_provider_extends_base(self):
+        from services.storage.providers import StorageProvider as SP
+
+        assert issubclass(CloudStorageProvider, SP)
+
+    def test_provider_capabilities_defined(self):
+        caps = ProviderCapabilities()
+        assert hasattr(caps, "public_urls")
+        assert hasattr(caps, "signed_urls")
+        assert hasattr(caps, "multipart_upload")
+        assert hasattr(caps, "versioning")
+        assert hasattr(caps, "metadata")
+        assert hasattr(caps, "streaming")

--- a/docs/architecture/0003-storage-service.md
+++ b/docs/architecture/0003-storage-service.md
@@ -1,0 +1,153 @@
+# ADR 0003: Storage Service
+
+## Status
+
+Accepted
+
+## Context
+
+Storage is a cross-product capability required by every application built
+by Palmshed. Products need to upload, download, and manage files without
+being coupled to a specific storage backend.
+
+Key requirements:
+
+- Provider-agnostic: support multiple storage backends (local, GCS, S3, R2, Azure)
+- Product-agnostic: zero coupling to any specific application
+- Minimal dependencies: mock and local providers work with stdlib only
+- Testable: mock provider for development and automated tests
+
+## Decision
+
+Introduce `services.storage` as a new Platform Service following the same
+architecture as `services.mail` and `services.auth`.
+
+### Architecture
+
+```text
+services/storage/
+├── __init__.py          # Public API re-exports
+├── config.py            # StorageConfig from env (single source of truth)
+├── models.py            # StorageObject, StorageResult, StorageStatus
+├── metrics.py           # StorageMetrics (upload/download/delete counts)
+├── logging.py           # Structured audit logging
+├── service.py           # StorageService (single public API)
+├── verify.py            # CLI for end-to-end verification
+├── README.md            # Versioning policy and usage guide
+└── providers/
+    ├── __init__.py       # Auto-registration + factory
+    ├── base.py           # StorageProvider ABC + ProviderCapabilities
+    ├── registry.py       # ProviderRegistry (register/create/available)
+    ├── mock.py           # MockStorageProvider (in-memory)
+    ├── local.py          # LocalStorageProvider (filesystem)
+    └── cloud.py          # CloudStorageProvider (interface stub)
+```
+
+### Provider interface
+
+```python
+class StorageProvider(ABC):
+    def upload(self, name, data, content_type=None, metadata=None) -> StorageResult
+    def download(self, name) -> StorageResult
+    def delete(self, name) -> StorageResult
+    def exists(self, name) -> StorageResult
+    def metadata(self, name) -> StorageResult
+    def list(self, prefix="") -> StorageResult
+    def signed_url(self, name, expires_in_seconds=3600) -> StorageResult
+```
+
+### ProviderCapabilities
+
+```python
+@dataclass
+class ProviderCapabilities:
+    public_urls: bool = True
+    signed_urls: bool = True
+    multipart_upload: bool = True
+    versioning: bool = True
+    metadata: bool = True
+    streaming: bool = True
+```
+
+### StorageService public API
+
+```python
+class StorageService:
+    def upload(self, name, data, content_type=None, metadata=None) -> StorageObject
+    def download(self, name) -> tuple[StorageObject, bytes]
+    def delete(self, name) -> StorageObject
+    def exists(self, name) -> bool
+    def metadata(self, name) -> StorageObject
+    def list(self, prefix="") -> list[str]
+    def signed_url(self, name, expires_in_seconds=3600) -> str
+    def health(self) -> StorageHealth
+```
+
+### Configuration
+
+All environment variables are read exclusively in `StorageConfig.from_env()`:
+
+- `STORAGE_PROVIDER` — provider name (default: `mock`)
+- `STORAGE_BUCKET` — logical bucket/container name (default: `alma`)
+- `STORAGE_BASE_PATH` — filesystem path for local provider
+- `STORAGE_PUBLIC_URL` — public base URL for serving objects
+- `MAX_UPLOAD_SIZE_MB` — maximum upload size in MB (default: `50`)
+
+### Providers
+
+**MockStorageProvider** — in-memory store. All capabilities enabled. No
+credentials or persistence required. Default for development and tests.
+
+**LocalStorageProvider** — filesystem-backed storage. Supports nested paths,
+metadata, and listing. Does not support public URLs or signed URLs.
+
+**CloudStorageProvider** — interface stub. All methods return FAILED with a
+message directing implementors to replace with GCS, S3, R2, or Azure.
+
+### Health integration
+
+The health endpoint instantiates `StorageService` lazily and includes the
+provider name, bucket, config validity, and liveness check in the response.
+
+```json
+{
+  "storage": {
+    "provider": "mock",
+    "config_valid": true,
+    "bucket": "alma",
+    "healthy": true
+  }
+}
+```
+
+### Verification CLI
+
+```bash
+python -m services.storage.verify
+```
+
+Performs: upload, exists check, download + checksum comparison, metadata
+fetch, delete, verify deletion, health check. Reports latency per step.
+
+## Consequences
+
+Positive:
+
+- Products can store files without choosing a backend
+- Mock provider enables isolated testing
+- Cloud provider stub documents the integration contract
+- Architecture boundary tests enforce product-agnostic constraints
+- Consistent architecture across mail, auth, and storage services
+
+Negative:
+
+- Local provider does not support signed URLs or public serving
+- Cloud storage requires a concrete implementation for production use
+- No streaming support in initial mock or local providers
+
+## References
+
+- ADR 0001: Platform Services
+- ADR 0002: Mail Service
+- `services/mail/` — reference implementation
+- `services/auth/` — reference implementation

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,201 @@
+# Storage System
+
+A shared storage capability for Palmshed products. Provider-agnostic
+and designed for future extraction into a standalone service.
+
+---
+
+## Architecture
+
+```
+Application (Alma, Via, Nuntius, ...)
+    ↓
+StorageService.upload/download/delete/exists/metadata/list/signed_url
+    ↓
+StorageProvider (Mock / Local / Cloud / GCS / S3 / R2 / Azure)
+    ↓
+Storage backend
+```
+
+Applications never talk directly to a storage backend.
+
+---
+
+## Public API
+
+```python
+from services.storage import StorageService, StorageConfig
+
+config = StorageConfig.from_env()
+svc = StorageService(config=config)
+
+# Upload
+obj = svc.upload("path/to/file.txt", data, content_type="text/plain")
+
+# Download
+obj, data = svc.download("path/to/file.txt")
+
+# Delete
+obj = svc.delete("path/to/file.txt")
+
+# Check existence
+exists = svc.exists("path/to/file.txt")
+
+# Metadata
+meta = svc.metadata("path/to/file.txt")
+
+# List
+objects = svc.list(prefix="path/to/")
+
+# Signed URL (if supported)
+url = svc.signed_url("path/to/file.txt", expires_in_seconds=3600)
+
+# Health
+health = svc.health()
+```
+
+---
+
+## Providers
+
+### Comparison
+
+| Feature           | Mock | Local | Cloud | GCS | S3 | R2 | Azure |
+|-------------------|------|-------|-------|-----|-----|-----|-------|
+| Status            | ✓    | ✓     | stub  | —    | —    | —    | —     |
+| Public URLs       | ✓    | ✗     | ✓     | —    | —    | —    | —     |
+| Signed URLs       | ✓    | ✗     | ✓     | —    | —    | —    | —     |
+| Metadata          | ✓    | ✓     | ✓     | —    | —    | —    | —     |
+| Multipart upload  | ✓    | ✗     | ✓     | —    | —    | —    | —     |
+| Versioning        | ✓    | ✗     | ✓     | —    | —    | —    | —     |
+| Streaming         | ✓    | ✗     | ✓     | —    | —    | —    | —     |
+
+### Mock
+
+Default provider. Stores objects in memory. No persistence across restarts.
+
+```
+STORAGE_PROVIDER=mock
+```
+
+### Local
+
+Stores objects on the local filesystem.
+
+```
+STORAGE_PROVIDER=local
+STORAGE_BASE_PATH=/var/data/palmshed/storage
+```
+
+### Cloud Interface Stub
+
+Placeholder for cloud providers. All operations return `FAILED` until
+replaced with a concrete implementation.
+
+```
+STORAGE_PROVIDER=cloud
+```
+
+### Adding a Provider
+
+1. Create `backend/services/storage/providers/gcs.py`
+2. Implement `StorageProvider` ABC
+3. Register in `providers/__init__.py`:
+   ```python
+   ProviderRegistry.register("gcs", GCSStorageProvider)
+   ```
+4. Set `STORAGE_PROVIDER=gcs`
+
+No application code changes needed.
+
+---
+
+## Configuration
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `STORAGE_PROVIDER` | `mock` | no | Provider name |
+| `STORAGE_BUCKET` | `alma` | no | Logical bucket/container name |
+| `STORAGE_BASE_PATH` | — | for local | Filesystem path for local provider |
+| `STORAGE_PUBLIC_URL` | — | no | Public base URL for serving objects |
+| `MAX_UPLOAD_SIZE_MB` | `50` | no | Maximum upload size in MB |
+
+---
+
+## Provider Capabilities
+
+Providers declare their capabilities at startup:
+
+```python
+@dataclass
+class ProviderCapabilities:
+    public_urls: bool     # Objects accessible at public URLs
+    signed_urls: bool     # Supports time-limited signed URLs
+    multipart_upload: bool  # Supports large file chunked uploads
+    versioning: bool      # Supports object versioning
+    metadata: bool        # Supports custom object metadata
+    streaming: bool       # Supports streaming upload/download
+```
+
+Applications can inspect capabilities before calling provider-specific
+features.
+
+---
+
+## Health
+
+`GET /api/health` includes storage status:
+
+```json
+{
+  "storage": {
+    "provider": "mock",
+    "config_valid": true,
+    "bucket": "alma",
+    "healthy": true
+  }
+}
+```
+
+Health check performs a write-read-delete cycle to verify the provider
+is operational.
+
+---
+
+## Verification CLI
+
+```bash
+python -m services.storage.verify
+```
+
+Tests all operations end-to-end:
+
+1. Upload a temporary object
+2. Verify it exists
+3. Download it and compare checksum
+4. Fetch metadata
+5. Delete it
+6. Verify deletion
+7. Check health
+
+Reports latency for each step.
+
+---
+
+## Development
+
+```bash
+# Default (mock provider, no setup needed)
+python -m services.storage.verify
+
+# Local filesystem
+STORAGE_PROVIDER=local STORAGE_BASE_PATH=/tmp/palmshed-test \
+  python -m services.storage.verify
+```
+
+---
+
+## Architecture
+
+See `docs/architecture/0003-storage-service.md` for the Architecture Decision
+Record.


### PR DESCRIPTION
## Summary

Adds Storage as the third Platform Service, following the same provider-agnostic architecture as Mail and Auth.

### Files

```
backend/services/storage/
├── __init__.py          # Public API re-exports
├── config.py            # StorageConfig.from_env()
├── models.py            # StorageObject, StorageResult, StorageStatus
├── metrics.py           # StorageMetrics
├── logging.py           # Structured audit logging
├── service.py           # StorageService (single public API)
├── verify.py            # CLI for end-to-end verification
├── README.md            # Usage guide
└── providers/
    ├── __init__.py       # Auto-registration + factory
    ├── base.py           # StorageProvider ABC + ProviderCapabilities
    ├── registry.py       # ProviderRegistry
    ├── mock.py           # In-memory store
    ├── local.py          # Filesystem-backed store
    └── cloud.py          # Interface stub for GCS/S3/R2/Azure
```

### Operations

- `upload()`, `download()`, `delete()`, `exists()`, `metadata()`, `list()`, `signed_url()`
- Health check with write-read-delete liveness probe

### Health endpoint

`GET /api/health` now includes:

```json
{"storage": {"provider": "mock", "config_valid": true, "bucket": "alma", "healthy": true}}
```

### Tests

90 tests — models, config, metrics, mock provider, local provider, cloud provider, registry, service, validation, health, architecture boundaries. All 269 suite tests pass.

### Documentation

- ADR: `docs/architecture/0003-storage-service.md`
- User docs: `docs/storage.md`
- `AGENTS.md` updated with Storage in platform tree