### PR TITLE
feat: add PlatformManager for centralized service initialization

### DIFF
--- a/backend/palmshed_ai/routes/api.py
+++ b/backend/palmshed_ai/routes/api.py
@@ -257,80 +257,8 @@ def research_topic() -> Union[Response, Tuple[Response, int]]:
 
 @api_bp.route("/api/health", methods=["GET"])
 def health_check():
-    """Health endpoint including mail provider status."""
-    from services.mail.config import MailConfig
-    from services.mail.service import MailService
+    """Health endpoint using PlatformManager."""
+    from services import platform
 
-    config = MailConfig.from_env()
-    mail_status = {"provider": config.provider, "from_email": config.from_email}
-
-    valid, errors = config.is_valid()
-    mail_status["config_valid"] = valid
-    if errors:
-        mail_status["config_errors"] = errors
-
-    try:
-        svc = MailService(config=config)
-        health = svc.health()
-        mail_status["provider"] = health.provider
-        mail_status["queue_running"] = health.queue_running
-        mail_status["queue_depth"] = health.queue_depth
-        mail_status["templates_valid"] = health.templates_valid
-        mail_status["template_count"] = health.template_count
-    except Exception as exc:
-        mail_status["error"] = str(exc)
-        logging.warning("Mail service health check failed: %s", exc)
-
-    auth_status = {"provider": "unknown"}
-    try:
-        from services.auth.config import AuthConfig
-        from services.auth.service import AuthService
-
-        auth_config = AuthConfig.from_env()
-        auth_status["provider"] = auth_config.provider
-        valid, errors = auth_config.is_valid()
-        auth_status["config_valid"] = valid
-        if errors:
-            auth_status["config_errors"] = errors
-        svc = AuthService(config=auth_config)
-        health = svc.health()
-        auth_status["provider"] = health.provider
-        auth_status["config_valid"] = health.config_valid
-        if health.config_errors:
-            auth_status["config_errors"] = health.config_errors
-    except Exception as exc:
-        auth_status["error"] = str(exc)
-        logging.warning("Auth service health check failed: %s", exc)
-
-    storage_status = {"provider": "unknown"}
-    try:
-        from services.storage.config import StorageConfig
-        from services.storage.service import StorageService
-
-        storage_config = StorageConfig.from_env()
-        storage_status["provider"] = storage_config.provider
-        storage_status["bucket"] = storage_config.bucket
-        valid, errors = storage_config.is_valid()
-        storage_status["config_valid"] = valid
-        if errors:
-            storage_status["config_errors"] = errors
-        svc = StorageService(config=storage_config)
-        health = svc.health()
-        storage_status["provider"] = health.provider
-        storage_status["config_valid"] = health.config_valid
-        storage_status["bucket"] = health.bucket
-        storage_status["healthy"] = health.healthy
-        if health.config_errors:
-            storage_status["config_errors"] = health.config_errors
-    except Exception as exc:
-        storage_status["error"] = str(exc)
-        logging.warning("Storage service health check failed: %s", exc)
-
-    return jsonify(
-        {
-            "status": "ok",
-            "mail": mail_status,
-            "auth": auth_status,
-            "storage": storage_status,
-        }
-    )
+    h = platform.health()
+    return jsonify(h.to_dict())

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,7 @@
+from .platform import PlatformManager, PlatformHealth, platform
+
+__all__ = [
+    "PlatformManager",
+    "PlatformHealth",
+    "platform",
+]

--- a/backend/services/platform.py
+++ b/backend/services/platform.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from services.auth.config import AuthConfig
+from services.auth.service import AuthService
+from services.mail.config import MailConfig
+from services.mail.service import MailService
+from services.storage.config import StorageConfig
+from services.storage.service import StorageService
+
+logger = logging.getLogger("palmshed.platform")
+
+
+class PlatformHealth:
+    def __init__(self) -> None:
+        self.status: str = "ok"
+        self.services: dict[str, dict] = {}
+        self.errors: list[str] = []
+
+    def to_dict(self) -> dict:
+        result: dict = {"status": self.status}
+        result.update(self.services)
+        if self.errors:
+            result["errors"] = self.errors
+        return result
+
+
+class PlatformManager:
+    def __init__(self) -> None:
+        self._mail: Optional[MailService] = None
+        self._auth: Optional[AuthService] = None
+        self._storage: Optional[StorageService] = None
+
+    @property
+    def mail(self) -> MailService:
+        if self._mail is None:
+            config = MailConfig.from_env()
+            self._mail = MailService(config=config)
+        return self._mail
+
+    @property
+    def auth(self) -> AuthService:
+        if self._auth is None:
+            config = AuthConfig.from_env()
+            self._auth = AuthService(config=config)
+        return self._auth
+
+    @property
+    def storage(self) -> StorageService:
+        if self._storage is None:
+            config = StorageConfig.from_env()
+            self._storage = StorageService(config=config)
+        return self._storage
+
+    def health(self) -> PlatformHealth:
+        health = PlatformHealth()
+
+        for name, svc in [
+            ("mail", self._try("mail", lambda: self.mail)),
+            ("auth", self._try("auth", lambda: self.auth)),
+            ("storage", self._try("storage", lambda: self.storage)),
+        ]:
+            if svc is not None:
+                try:
+                    health.services[name] = self._service_health(name, svc)
+                except Exception as exc:
+                    health.services[name] = {"error": str(exc)}
+                    health.errors.append(f"{name}: {exc}")
+                    logger.warning("%s health check failed: %s", name, exc)
+            else:
+                health.services[name] = {"error": "service unavailable"}
+
+        if health.errors:
+            health.status = "degraded"
+
+        return health
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        if self._mail is not None:
+            try:
+                self._mail.shutdown(timeout)
+            except Exception as exc:
+                logger.warning("Mail shutdown error: %s", exc)
+
+    def _try(self, name: str, fn):
+        try:
+            return fn()
+        except Exception as exc:
+            logger.warning("Failed to initialize %s: %s", name, exc)
+            return None
+
+    def _service_health(self, name: str, svc) -> dict:
+        if name == "mail":
+            h = svc.health()
+            return {
+                "provider": h.provider,
+                "config_valid": h.config_valid,
+                "queue_running": h.queue_running,
+                "queue_depth": h.queue_depth,
+                "templates_valid": h.templates_valid,
+                "template_count": h.template_count,
+            }
+        if name == "auth":
+            h = svc.health()
+            return {
+                "provider": h.provider,
+                "config_valid": h.config_valid,
+            }
+        if name == "storage":
+            h = svc.health()
+            return {
+                "provider": h.provider,
+                "config_valid": h.config_valid,
+                "bucket": h.bucket,
+                "healthy": h.healthy,
+            }
+        return {}
+
+
+platform = PlatformManager()


### PR DESCRIPTION
## Summary

Creates a `PlatformManager` that centralizes the initialization, health reporting, and shutdown of all platform services (Mail, Auth, Storage).

### Before

Each route handler or test constructed services individually.

### After

```python
from services import platform

platform.mail.send(...)
platform.auth.login(...)
platform.storage.upload(...)
h = platform.health()
```

### Changes

- `services/platform.py` — PlatformManager with lazy init, `.health()`, `.shutdown()`
- `services/__init__.py` — exports `platform` singleton
- `routes/api.py` — `GET /api/health` simplified from 76 lines to 5
