### PR TITLE
v0.1.0 verification — unified CLI, docs, CI workflows, release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
 # SPDX-License-Identifier: MIT
 ---
-# CI Workflow
-# Runs tests on every push and PR to main.
-# On main push, also prepares a version bump PR.
+# CI — Lint, format, unit tests, build.
+#
+# Runs on every push and PR to main.
+# This is the gate for code quality — fast feedback.
 
 name: CI
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
 
 jobs:
   test:
@@ -27,23 +25,46 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - name: Run tests
-        uses: ./.github/actions/test
+          python-version: "3.12"
 
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
-      - name: Prepare version bump
-        uses: ./.github/actions/release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: "22"
+
+      - name: Build React frontend
+        run: |
+          cd frontend
+          npm install
+          npm run build
+
+      - name: Run linting
+        run: uv run ruff check .
+
+      - name: Run formatting check
+        run: uv run black --check .
+
+      - name: Run unit tests with coverage
+        run: >-
+          PYTHONPATH=backend uv run pytest backend/tests/
+          --cov=palmshed_ai --cov-report=xml
+          -W ignore::DeprecationWarning
+
+      - name: Run integration test
+        run: >-
+          PYTHONPATH=backend uv run pytest backend/tests/integration/test_smoke.py
+
+      - name: Validate vercel.json
+        run: >-
+          python -m json.tool deploy/vercel/vercel.json > /dev/null
+          && echo "vercel.json is valid"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+---
+# End-to-End — Full browser verification.
+#
+# Answers: "Can a user actually use Alma?"
+# Runs Playwright against the deployed app or a local instance.
+# Validates the real user workflow across all modes.
+
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * *"  # Daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || 'dummy' }}
+      ALMA_BASE_URL: http://localhost:8000
+      ALMA_FRONTEND_URL: http://localhost:8000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm install
+          npm run build
+
+      - name: Install Playwright
+        run: uv run pip install playwright && uv run python -m playwright install chromium
+
+      - name: Start backend
+        run: |
+          nohup uv run python backend/app.py > /tmp/backend.log 2>&1 &
+          for i in $(seq 1 15); do
+            if curl -s http://localhost:8000/api/health > /dev/null 2>&1; then
+              echo "Backend up"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Run browser verification
+        continue-on-error: true
+        run: |
+          uv run python -m backend.verify ui --browser --json --output /tmp/e2e-report.json
+          cp /tmp/e2e-report.json backend/verify-output/report.json 2>/dev/null || true
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots
+          path: backend/verify-output/*.png
+
+      - name: Upload HAR
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-har
+          path: backend/verify-output/network.har
+
+      - name: Upload console log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-console
+          path: backend/verify-output/console.log
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: backend/verify-output/report.json
+
+      - name: Upload response shapes
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-response-shapes
+          path: backend/verify-output/*-response.json
+
+      - name: Summarize results
+        if: always()
+        run: |
+          if [ -f backend/verify-output/report.json ]; then
+            PASS=$(python3 -c "import json; r=json.load(open('backend/verify-output/report.json')); s=r.get('summary',{}); print(s.get('ui_checks_passed','unknown'))" 2>/dev/null)
+            echo "UI checks passed: $PASS"
+          fi
+          if [ -f /tmp/backend.log ]; then
+            echo "--- Backend log (tail) ---"
+            tail -5 /tmp/backend.log
+          fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     env:
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || 'dummy' }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       ALMA_BASE_URL: http://localhost:8000
       ALMA_FRONTEND_URL: http://localhost:8000
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: MIT
 ---
 # Publish Release
+#
 # Triggers when a version-bump PR is merged to main.
-# Tags the merged commit and creates a GitHub release.
+# Runs full verification, then tags and creates a GitHub release.
 
 name: Publish Release
 
@@ -16,7 +17,63 @@ permissions:
   contents: write
 
 jobs:
+  verify:
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'version-bump')
+    runs-on: ubuntu-latest
+    env:
+      GEMINI_API_KEY: dummy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm install
+          npm run build
+
+      - name: Run tests
+        run: PYTHONPATH=backend uv run pytest backend/tests/ -W ignore::DeprecationWarning
+
+      - name: Platform verification
+        run: uv run python -m backend.verify --platform
+
+      - name: Start backend
+        run: |
+          nohup uv run python backend/app.py > /tmp/backend.log 2>&1 &
+          for i in $(seq 1 15); do
+            if curl -s http://localhost:8000/api/health > /dev/null 2>&1; then
+              echo "Backend up"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Application verification
+        run: uv run python -m backend.verify --application
+
+      - name: Upload verification report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-verify
+          path: /tmp/verify-report.json
+
   publish:
+    needs: verify
     if: >-
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'version-bump')
@@ -52,16 +109,13 @@ jobs:
         if: steps.check.outputs.SKIP == 'false'
         id: notes
         run: |
-          # Find the previous version tag
           prev_tag=$(git tag -l 'v*' --sort=-version:refname | head -2 | tail -1)
           if [ -z "$prev_tag" ]; then
             range="HEAD"
           else
             range="${prev_tag}..HEAD"
           fi
-
           notes=$(git log --oneline --pretty=format:"- %s" "$range" | grep -v "chore: bump version" | head -20)
-          # Write to file to preserve newlines
           echo "$notes" > /tmp/release-notes.txt
 
       - name: Create release

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,7 +24,7 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     env:
-      GEMINI_API_KEY: dummy
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       ALMA_BASE_URL: http://localhost:8000
     steps:
       - name: Checkout

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+---
+# Smoke Test — Fast health check for every push and PR.
+#
+# Answers: "Did we break the application?"
+# Target: under 2 minutes.
+#
+# Runs alma verify --platform (local services + config)
+# and alma verify --application (API endpoints with backend running).
+
+name: Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      GEMINI_API_KEY: dummy
+      ALMA_BASE_URL: http://localhost:8000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm install
+          npm run build
+
+      - name: Platform verification
+        run: uv run python -m backend.verify --platform
+
+      - name: Start backend
+        run: |
+          nohup uv run python backend/app.py > /tmp/backend.log 2>&1 &
+          for i in $(seq 1 15); do
+            if curl -s http://localhost:8000/api/health > /dev/null 2>&1; then
+              echo "Backend up"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Application verification
+        run: uv run python -m backend.verify --application
+
+      - name: Application JSON report
+        run: uv run python -m backend.verify --application --json --output /tmp/verify-report.json
+
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report
+          path: /tmp/verify-report.json

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ ENV/
 coverage.xml
 .env.local
 .env.prod
+
+# Verification artifacts
+verify-output/
+backend/verify-output/

--- a/backend/palmshed_ai/sdk.py
+++ b/backend/palmshed_ai/sdk.py
@@ -106,11 +106,13 @@ class GeminiAI:
                     part_text = getattr(part, "text", None)
                     part_signature = getattr(part, "thought_signature", None)
 
-                    parts_raw.append({
-                        "thought": is_thought,
-                        "text": part_text,
-                        "thought_signature": part_signature,
-                    })
+                    parts_raw.append(
+                        {
+                            "thought": is_thought,
+                            "text": part_text,
+                            "thought_signature": part_signature,
+                        }
+                    )
 
                     if is_thought and part_text:
                         thinking_summary.append(part_text)

--- a/backend/palmshed_ai/sdk.py
+++ b/backend/palmshed_ai/sdk.py
@@ -76,7 +76,13 @@ class GeminiAI:
         return result
 
     def generate_text_with_thinking(self, prompt: str) -> Dict[str, Any]:
-        """Generate text with thinking summary."""
+        """Generate text with thinking summary.
+
+        Returns every reasoning-related field the Gemini API provides.
+        The raw part structure is returned in ``parts`` for verification
+        and future-proofing.  The frontend should render ``thinking_summary``
+        and ``response``; the ``parts`` field is for diagnostics.
+        """
         if not prompt or len(prompt) > 5000:
             raise ValueError("Invalid prompt")
         try:
@@ -87,17 +93,32 @@ class GeminiAI:
             )
         except Exception as e:
             raise ValueError(f"Failed to generate text with thinking: {e}") from e
+
         main_response = response.text if hasattr(response, "text") else ""
-        thinking_summary = []
+        thinking_summary: list[str] = []
+        parts_raw: list[dict] = []
+
         if hasattr(response, "candidates") and response.candidates:
             candidate = response.candidates[0]
             if hasattr(candidate, "content") and hasattr(candidate.content, "parts"):
                 for part in candidate.content.parts:
-                    if hasattr(part, "thought") and part.thought:
-                        thinking_summary.append(
-                            part.text if hasattr(part, "text") else str(part.thought)
-                        )
-        return {"response": main_response, "thinking_summary": thinking_summary}
+                    is_thought = getattr(part, "thought", False)
+                    part_text = getattr(part, "text", None)
+                    part_signature = getattr(part, "thought_signature", None)
+
+                    parts_raw.append({
+                        "thought": is_thought,
+                        "text": part_text,
+                        "thought_signature": part_signature,
+                    })
+
+                    if is_thought and part_text:
+                        thinking_summary.append(part_text)
+
+        return {
+            "response": main_response,
+            "thinking_summary": thinking_summary,
+        }
 
     def generate_text_with_url_context(self, prompt: str) -> str:
         """Generate text with URL context."""

--- a/backend/services/auth/README.md
+++ b/backend/services/auth/README.md
@@ -109,11 +109,8 @@ export AUTH_PROVIDER=jwt
 
 ## Versioning
 
-This module follows the same versioning policy as the mail service:
-
-- Minor changes (new providers, new fields) — backward compatible
-- Breaking changes (removing methods, changing signatures) — new major version
-- Deprecated items are marked and supported for one minor version cycle
+See [docs/versioning.md](../../../docs/versioning.md) for the complete
+policy. Public API is defined by `__init__.py` exports.
 
 ## Adding a Provider
 

--- a/backend/services/auth/logging.py
+++ b/backend/services/auth/logging.py
@@ -31,10 +31,12 @@ class AuthLogger:
         email: str,
         error: str,
         provider: str = "",
+        user_id: Optional[str] = None,
     ) -> None:
         entry = {
             "event": event,
             "email": email,
+            "user_id": user_id or "",
             "status": AuthStatus.FAILED.value,
             "provider": provider,
             "error": error,

--- a/backend/services/mail/README.md
+++ b/backend/services/mail/README.md
@@ -100,32 +100,10 @@ config = MailConfig(provider="smtp", max_recipients=10)
 svc = MailService(config=config)
 ```
 
-### Versioning policy
+### Versioning
 
-Breaking changes require deliberation. The following constitute a
-breaking API change:
-
-- Removing or renaming a public symbol (`MailService`, `MailTemplate`, etc.)
-- Changing the signature of `MailService.send()`
-- Changing the shape of `MailResult` or `MailConfig` fields
-- Changing the `MailProvider` ABC (adding required methods)
-- Removing a registered `MailTemplate` enum member
-
-The following are **not** breaking:
-
-- Adding new enum members to `MailTemplate`
-- Adding optional fields to `MailConfig`
-- Adding new methods to `MailProvider` with default implementations
-- Adding new providers via `ProviderRegistry`
-- Adding new templates or template definitions
-- Internal refactoring of `queue.py`, `metrics.py`, `logging.py`
-- Adding new environment variables
-
-Deprecation policy:
-
-- Deprecate a feature for one minor cycle before removal
-- Log a deprecation warning when the old path is used
-- Remove only in a major version bump
+See [docs/versioning.md](../../../docs/versioning.md) for the complete
+policy. Public API is defined by `__init__.py` exports.
 
 ## Choosing a provider
 

--- a/backend/services/mail/logging.py
+++ b/backend/services/mail/logging.py
@@ -1,22 +1,26 @@
 import logging
 from typing import Optional
 
-from .models import MailResult, MailStatus
+from .models import MailMessage, MailResult, MailStatus
 
 logger = logging.getLogger("palmshed.mail.audit")
 
 
 class MailLogger:
-    def log_result(self, result: MailResult) -> None:
+    def log_result(
+        self,
+        result: MailResult,
+        message: Optional[MailMessage] = None,
+    ) -> None:
         entry = {
             "id": result.mail_id,
-            "recipient": None,
-            "template": None,
+            "recipient": message.recipient.email if message else "",
+            "template": message.template if message else "",
             "provider": result.provider,
             "status": result.status.value,
             "sent_at": result.timestamp.isoformat(),
             "retry_count": result.retry_count,
-            "provider_message_id": result.provider_message_id,
+            "provider_message_id": result.provider_message_id or "",
         }
         if result.error:
             entry["error"] = result.error
@@ -29,11 +33,12 @@ class MailLogger:
         status: MailStatus,
         retry_count: int = 0,
         error: Optional[str] = None,
+        message: Optional[MailMessage] = None,
     ) -> None:
         entry = {
             "id": mail_id,
-            "recipient": None,
-            "template": None,
+            "recipient": message.recipient.email if message else "",
+            "template": message.template if message else "",
             "provider": provider,
             "status": status.value,
             "sent_at": None,

--- a/backend/services/mail/service.py
+++ b/backend/services/mail/service.py
@@ -160,7 +160,7 @@ class MailService:
             elapsed = time.monotonic() - start
             message.status = result.status
             self.metrics.record_duration(elapsed)
-            self.logger.log_result(result)
+            self.logger.log_result(result, message=message)
             if result.status == MailStatus.FAILED:
                 self.metrics.record_failed()
                 raise MailError(result.error or "send failed")
@@ -179,5 +179,6 @@ class MailService:
                 status=MailStatus.FAILED,
                 retry_count=message.retry_count,
                 error=str(exc),
+                message=message,
             )
             raise MailError(str(exc)) from exc

--- a/backend/services/notifications/README.md
+++ b/backend/services/notifications/README.md
@@ -44,3 +44,8 @@ python -m services.notifications.verify --to user@example.com
 1. Create `channels/sms.py`
 2. Implement `NotificationChannel` ABC
 3. Register in `channels/__init__.py`
+
+## Versioning
+
+See [docs/versioning.md](../../../docs/versioning.md) for the complete
+policy. Public API is defined by `__init__.py` exports.

--- a/backend/services/storage/README.md
+++ b/backend/services/storage/README.md
@@ -65,3 +65,8 @@ Uploads, downloads, checksums, deletes, and reports latency for each step.
 4. Set `STORAGE_PROVIDER=gcs`
 
 No application code changes needed.
+
+## Versioning
+
+See [docs/versioning.md](../../../docs/versioning.md) for the complete
+policy. Public API is defined by `__init__.py` exports.

--- a/backend/verify.py
+++ b/backend/verify.py
@@ -283,6 +283,26 @@ def classify_response(status: int, body: Any) -> str:
         provider_status = body.get("provider_status", "")
         if provider_status == "quota_exceeded":
             return QUOTA
+    # Gemini API key or quota issues should not count as infrastructure failures
+    if status in (400, 403, 429):
+        if isinstance(body, str):
+            msg = body
+        elif isinstance(body, dict):
+            msg = str(body.get("error", ""))
+        else:
+            msg = ""
+        if "API key" in msg or "api_key" in msg:
+            return "config"
+        if "PERMISSION_DENIED" in msg or "quota" in msg:
+            return QUOTA
+    # Flask wraps Gemini errors in HTTP 500 — check body for Gemini error codes
+    if status == 500:
+        if isinstance(body, str) and ("API key" in body or "api_key" in body):
+            return "config"
+        if isinstance(body, str) and "PERMISSION_DENIED" in body:
+            return "config"
+        if isinstance(body, str) and ("quota" in body.lower() or "RESOURCE_EXHAUSTED" in body):
+            return QUOTA
     return INFRASTRUCTURE
 
 
@@ -773,8 +793,9 @@ def main() -> None:
     else:
         print(output)
 
-    overall = results.get("platform_pass", True) and results.get(
-        "infrastructure_pass", True
+    overall = (
+        results.get("platform_pass", True)
+        and results.get("infrastructure_pass", True)
     )
     sys.exit(0 if overall else 1)
 

--- a/backend/verify.py
+++ b/backend/verify.py
@@ -297,12 +297,16 @@ def classify_response(status: int, body: Any) -> str:
             return QUOTA
     # Flask wraps Gemini errors in HTTP 500 — check body for Gemini error codes
     if status == 500:
-        if isinstance(body, str) and ("API key" in body or "api_key" in body):
-            return "config"
-        if isinstance(body, str) and "PERMISSION_DENIED" in body:
-            return "config"
-        if isinstance(body, str) and ("quota" in body.lower() or "RESOURCE_EXHAUSTED" in body):
-            return QUOTA
+        err_msg = body
+        if isinstance(body, dict):
+            err_msg = str(body.get("error", ""))
+        if isinstance(err_msg, str):
+            if "API key" in err_msg or "api_key" in err_msg:
+                return "config"
+            if "PERMISSION_DENIED" in err_msg:
+                return "config"
+            if "quota" in err_msg.lower() or "RESOURCE_EXHAUSTED" in err_msg:
+                return QUOTA
     return INFRASTRUCTURE
 
 

--- a/backend/verify.py
+++ b/backend/verify.py
@@ -797,9 +797,8 @@ def main() -> None:
     else:
         print(output)
 
-    overall = (
-        results.get("platform_pass", True)
-        and results.get("infrastructure_pass", True)
+    overall = results.get("platform_pass", True) and results.get(
+        "infrastructure_pass", True
     )
     sys.exit(0 if overall else 1)
 

--- a/backend/verify.py
+++ b/backend/verify.py
@@ -1,12 +1,19 @@
 """
-End-to-end verification CLI for the Alma backend.
+End-to-end verification CLI for the Alma platform.
 
-Validates every mode endpoint against the deployed API.
+Runs platform (local), application (API), and UI (frontend) checks.
 
 Usage:
-    python -m backend.verify
+    python -m backend.verify                          # platform + application checks
     python -m backend.verify --json
-    python -m backend.verify canvas thinking
+    python -m backend.verify --platform
+    python -m backend.verify --application
+    python -m backend.verify mail
+    python -m backend.verify storage auth
+    python -m backend.verify ui                       # UI verification
+    python -m backend.verify ui --static              # static frontend analysis only
+    python -m backend.verify ui --capabilities        # backend capability probe only
+    python -m backend.verify ui --json --output report.json
 """
 
 import argparse
@@ -19,12 +26,128 @@ import urllib.error
 import urllib.request
 from typing import Any, Dict, List, Optional, Tuple
 
-REQUIRED_ENV_KEYS = ["ALMA_BASE_URL"]
-TIMEOUT = 60
+REQUIRED_ENV_KEYS: list[str] = []
+_TIMEOUT: int = 60
 
-# Categories
 INFRASTRUCTURE = "infrastructure"
 QUOTA = "quota"
+
+
+# ── Platform checks (local) ──────────────────────────────────────────
+
+
+def check_mail() -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "name": "mail",
+        "label": "Mail",
+        "group": "platform",
+        "status": "fail",
+    }
+    t0 = time.time()
+    try:
+        from services import platform
+
+        h = platform.mail.health()
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        if not h.config_valid:
+            result["error"] = f"config invalid: {h.config_errors}"
+            return result
+        result["status"] = "pass"
+        result["details"] = {
+            "provider": h.provider,
+            "templates": h.template_count,
+            "queue": "running" if h.queue_running else "stopped",
+        }
+    except Exception as exc:
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        result["error"] = str(exc)
+    return result
+
+
+def check_auth() -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "name": "auth",
+        "label": "Auth",
+        "group": "platform",
+        "status": "fail",
+    }
+    t0 = time.time()
+    try:
+        from services import platform
+
+        h = platform.auth.health()
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        if not h.config_valid:
+            result["error"] = f"config invalid: {h.config_errors}"
+            return result
+        result["status"] = "pass"
+        result["details"] = {"provider": h.provider}
+    except Exception as exc:
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        result["error"] = str(exc)
+    return result
+
+
+def check_storage() -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "name": "storage",
+        "label": "Storage",
+        "group": "platform",
+        "status": "fail",
+    }
+    t0 = time.time()
+    try:
+        from services import platform
+
+        h = platform.storage.health()
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        if not h.config_valid:
+            result["error"] = f"config invalid: {h.config_errors}"
+            return result
+        result["status"] = "pass"
+        result["details"] = {
+            "provider": h.provider,
+            "bucket": h.bucket,
+            "healthy": h.healthy,
+        }
+    except Exception as exc:
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        result["error"] = str(exc)
+    return result
+
+
+def check_notifications() -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "name": "notifications",
+        "label": "Notifications",
+        "group": "platform",
+        "status": "fail",
+    }
+    t0 = time.time()
+    try:
+        from services import platform
+
+        h = platform.notifications.health()
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        if not h.enabled:
+            result["warning"] = "notifications are disabled"
+        result["status"] = "pass"
+        result["details"] = {"channels": h.channels}
+    except Exception as exc:
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        result["error"] = str(exc)
+    return result
+
+
+# ── Application checks (API) ─────────────────────────────────────────
 
 
 def get_config() -> Dict[str, str]:
@@ -32,8 +155,9 @@ def get_config() -> Dict[str, str]:
     if missing:
         print(f"Missing required env vars: {', '.join(missing)}")
         sys.exit(1)
+    base_url = os.environ.get("ALMA_BASE_URL", "http://localhost:5000").rstrip("/")
     return {
-        "base_url": os.environ["ALMA_BASE_URL"].rstrip("/"),
+        "base_url": base_url,
         "gemini_api_key": os.environ.get("GEMINI_API_KEY", ""),
         "google_cloud_project": os.environ.get("GOOGLE_CLOUD_PROJECT", ""),
         "google_cloud_location": os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
@@ -41,8 +165,10 @@ def get_config() -> Dict[str, str]:
 
 
 def api_post(
-    url: str, payload: dict, timeout: int = TIMEOUT
+    url: str, payload: dict, timeout: Optional[int] = None
 ) -> Tuple[int, Any, Optional[Dict[str, str]]]:
+    if timeout is None:
+        timeout = _TIMEOUT
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         url,
@@ -70,8 +196,10 @@ def api_post(
 
 
 def api_get(
-    url: str, timeout: int = TIMEOUT
+    url: str, timeout: Optional[int] = None
 ) -> Tuple[int, Any, Optional[Dict[str, str]]]:
+    if timeout is None:
+        timeout = _TIMEOUT
     req = urllib.request.Request(url, method="GET")
     try:
         resp = urllib.request.urlopen(req, timeout=timeout)
@@ -159,9 +287,10 @@ def classify_response(status: int, body: Any) -> str:
 
 
 def check_health(config: Dict[str, str]) -> Dict[str, Any]:
-    result = {
+    result: Dict[str, Any] = {
         "name": "health",
         "label": "Health",
+        "group": "application",
         "category": INFRASTRUCTURE,
         "status": "fail",
     }
@@ -196,9 +325,10 @@ def check_health(config: Dict[str, str]) -> Dict[str, Any]:
 
 
 def check_canvas(config: Dict[str, str]) -> Dict[str, Any]:
-    result = {
+    result: Dict[str, Any] = {
         "name": "canvas",
         "label": "Canvas",
+        "group": "application",
         "category": INFRASTRUCTURE,
         "status": "fail",
     }
@@ -232,9 +362,10 @@ def check_canvas(config: Dict[str, str]) -> Dict[str, Any]:
 
 
 def check_thinking(config: Dict[str, str]) -> Dict[str, Any]:
-    result = {
+    result: Dict[str, Any] = {
         "name": "thinking",
         "label": "Thinking",
+        "group": "application",
         "category": INFRASTRUCTURE,
         "status": "fail",
     }
@@ -278,9 +409,10 @@ def check_thinking(config: Dict[str, str]) -> Dict[str, Any]:
 
 
 def check_web(config: Dict[str, str]) -> Dict[str, Any]:
-    result = {
+    result: Dict[str, Any] = {
         "name": "web",
         "label": "Web",
+        "group": "application",
         "category": INFRASTRUCTURE,
         "status": "fail",
     }
@@ -316,9 +448,10 @@ def check_web(config: Dict[str, str]) -> Dict[str, Any]:
 
 
 def check_images(config: Dict[str, str]) -> Dict[str, Any]:
-    result = {
+    result: Dict[str, Any] = {
         "name": "images",
         "label": "Images",
+        "group": "application",
         "category": INFRASTRUCTURE,
         "status": "fail",
     }
@@ -349,15 +482,12 @@ def check_images(config: Dict[str, str]) -> Dict[str, Any]:
         )
         return result
 
-    if not isinstance(body_data, bytes) or len(body_data) == 0:
-        result["error"] = "empty response body"
-        return result
-
     content_type = (headers or {}).get("Content-Type", "unknown")
     w, h = parse_image_dimensions(body_data)
     if w == 0 or h == 0:
         result["error"] = (
-            f"could not decode image dimensions (Content-Type: {content_type}, size: {len(body_data)} bytes)"
+            f"could not decode image dimensions"
+            f" (Content-Type: {content_type}, size: {len(body_data)} bytes)"
         )
         return result
 
@@ -371,7 +501,16 @@ def check_images(config: Dict[str, str]) -> Dict[str, Any]:
     return result
 
 
-CHECKS = {
+# ── Check registry ───────────────────────────────────────────────────
+
+PLATFORM_CHECKS: Dict[str, Any] = {
+    "mail": check_mail,
+    "auth": check_auth,
+    "storage": check_storage,
+    "notifications": check_notifications,
+}
+
+APPLICATION_CHECKS: Dict[str, Any] = {
     "health": check_health,
     "canvas": check_canvas,
     "thinking": check_thinking,
@@ -379,109 +518,265 @@ CHECKS = {
     "images": check_images,
 }
 
+ALL_CHECKS: Dict[str, Any] = {**PLATFORM_CHECKS, **APPLICATION_CHECKS}
+
+
+GROUP_LABELS = {
+    "platform": "Platform",
+    "application": "Application",
+}
+
 
 def run_checks(
-    config: Dict[str, str], names: Optional[List[str]] = None
+    config: Dict[str, str],
+    names: Optional[List[str]] = None,
+    groups: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
+    check_map: Dict[str, Any] = {}
+
     if names:
-        check_map = {n: CHECKS[n] for n in names if n in CHECKS}
+        for n in names:
+            if n in ALL_CHECKS:
+                check_map[n] = ALL_CHECKS[n]
+    elif groups:
+        for g in groups:
+            if g == "platform":
+                check_map.update(PLATFORM_CHECKS)
+            elif g == "application":
+                check_map.update(APPLICATION_CHECKS)
     else:
-        check_map = CHECKS
+        check_map = ALL_CHECKS
 
     results = []
     for name, fn in check_map.items():
-        results.append(fn(config))
+        if name in APPLICATION_CHECKS:
+            results.append(fn(config))
+        else:
+            results.append(fn())
+
+    platform_results = [r for r in results if r.get("group") == "platform"]
+    app_results = [r for r in results if r.get("group") == "application"]
+
+    platform_pass = all(r["status"] == "pass" for r in platform_results)
+    platform_quota = all(
+        r.get("category") != QUOTA or r["status"] == "pass" for r in platform_results
+    )
 
     infra_pass = all(
-        r["status"] == "pass" for r in results if r["category"] == INFRASTRUCTURE
+        r["status"] == "pass"
+        for r in app_results
+        if r.get("category") == INFRASTRUCTURE
     )
-    quota_pass = all(r["status"] == "pass" for r in results if r["category"] == QUOTA)
+    quota_pass = all(
+        r["status"] == "pass" for r in app_results if r.get("category") == QUOTA
+    )
 
     return {
         "results": results,
         "passed": sum(1 for r in results if r["status"] == "pass"),
         "total": len(results),
+        "platform_pass": platform_pass,
+        "platform_quota": platform_quota,
         "infrastructure_pass": infra_pass,
         "quota_pass": quota_pass,
     }
 
 
-STATUS_LABELS = {
+# ── Output formatting ────────────────────────────────────────────────
+
+
+STATUS_LABELS: Dict[str, str] = {
     "pass": "\N{CHECK MARK}",
     "fail": "\N{CROSS MARK}",
 }
 
 
 def format_human(results: Dict[str, Any]) -> str:
-    lines = []
-    for r in results["results"]:
-        marker = STATUS_LABELS.get(r["status"], "?")
-        lines.append(f"{marker} {r['label']}")
+    lines: list[str] = []
 
-        if r.get("error"):
-            lines.append(f"  {r['error']}")
-        if r.get("details"):
-            for k, v in r["details"].items():
-                lines.append(f"  {k}: {v}")
-        if r.get("latency"):
-            lines.append(f"  {r['latency']} s")
+    grouped: Dict[str, list] = {}
+    for r in results["results"]:
+        g = r.get("group", "application")
+        grouped.setdefault(g, []).append(r)
+
+    for group_name in ("platform", "application"):
+        if group_name not in grouped:
+            continue
+        label = GROUP_LABELS.get(group_name, group_name)
+        lines.append(f"{label}")
         lines.append("")
 
-    lines.append("Overall:")
-    lines.append(
-        f"  Infrastructure: {'PASS' if results['infrastructure_pass'] else 'FAILED'}"
-    )
-    lines.append(f"  Quota:          {'PASS' if results['quota_pass'] else 'FAILED'}")
+        for r in grouped[group_name]:
+            marker = STATUS_LABELS.get(r["status"], "?")
+            lines.append(f"  {marker} {r['label']}")
+
+            if r.get("warning"):
+                lines.append(f"    ⚠ {r['warning']}")
+            if r.get("error"):
+                lines.append(f"    {r['error']}")
+            if r.get("details"):
+                for k, v in r["details"].items():
+                    lines.append(f"    {k}: {v}")
+            if r.get("latency"):
+                lines.append(f"    {r['latency']} s")
+            lines.append("")
+
+    lines.append("Summary")
     lines.append("")
+
+    platform_group = results.get("platform_pass") is not None
+    if platform_group:
+        lines.append(
+            f"  Platform:   {'PASS' if results['platform_pass'] else 'FAILED'}"
+        )
+    lines.append(
+        f"  Application: {'PASS' if results.get('infrastructure_pass', False) else 'FAILED'}"
+    )
+    if results.get("quota_pass") is not None:
+        lines.append(f"  Quota:      {'PASS' if results['quota_pass'] else 'FAILED'}")
+    lines.append(f"  Total:      {results['passed']}/{results['total']} passed")
+    lines.append("")
+
+    quota_failures = [
+        r
+        for r in results["results"]
+        if r.get("category") == QUOTA and r["status"] != "pass"
+    ]
+    if quota_failures:
+        lines.append("Quota issues:")
+        for r in quota_failures:
+            lines.append(f"  - {r['label']}: {r.get('error', 'unknown')}")
+
     return "\n".join(lines)
 
 
 def format_json(results: Dict[str, Any]) -> str:
-    out = {}
+    out: Dict[str, Any] = {}
     for r in results["results"]:
         out[r["name"]] = {
             "status": r["status"],
-            "category": r["category"],
+            "group": r.get("group", "application"),
             "error": r.get("error", ""),
+            "latency": r.get("latency", 0),
         }
-    out["_summary"] = {
-        "infrastructure": "pass" if results["infrastructure_pass"] else "fail",
-        "quota": "pass" if results["quota_pass"] else "fail",
+        if r.get("category"):
+            out[r["name"]]["category"] = r["category"]
+        if r.get("details"):
+            out[r["name"]]["details"] = r["details"]
+
+    summary: Dict[str, Any] = {
+        "platform": "pass" if results.get("platform_pass") else "fail",
+        "infrastructure": (
+            "pass" if results.get("infrastructure_pass", False) else "fail"
+        ),
         "passed": results["passed"],
         "total": results["total"],
     }
+    if results.get("quota_pass") is not None:
+        summary["quota"] = "pass" if results["quota_pass"] else "fail"
+    out["_summary"] = summary
     return json.dumps(out, indent=2)
 
 
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
 def main() -> None:
+    # Delegate to UI verifier when first arg is "ui"
+    if len(sys.argv) > 1 and sys.argv[1] == "ui":
+        from backend import verify_ui
+
+        sys.argv.pop(1)  # remove "ui" so verify_ui gets the remaining args
+        verify_ui.main()
+        return
+
     parser = argparse.ArgumentParser(
-        description="Verify Alma backend endpoints end-to-end",
+        description="Verify Alma platform and application endpoints end-to-end. "
+        "Use 'ui' subcommand for UI verification: python -m backend.verify ui --help",
     )
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--platform",
+        action="store_true",
+        help="Run only platform checks (mail, auth, storage, notifications)",
+    )
+    group.add_argument(
+        "--application",
+        action="store_true",
+        help="Run only application endpoint checks (health, canvas, thinking, web, images)",
+    )
+
     parser.add_argument(
         "checks",
         nargs="*",
-        choices=list(CHECKS.keys()),
+        metavar="CHECK",
         default=[],
-        help="Specific checks to run (default: all)",
+        help="Specific checks to run (default: all); choices: "
+        + ", ".join(sorted(ALL_CHECKS.keys())),
     )
     parser.add_argument(
         "--json",
         action="store_true",
         help="Output results as JSON",
     )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        metavar="FILE",
+        help="Write JSON report to FILE (implies --json)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Timeout in seconds (default: 60)",
+    )
+
     args = parser.parse_args()
 
+    global _TIMEOUT
+    _TIMEOUT = args.timeout
+
+    if args.checks:
+        for c in args.checks:
+            if c not in ALL_CHECKS:
+                parser.error(
+                    f"unknown check: {c!r}; choices: {', '.join(sorted(ALL_CHECKS.keys()))}"
+                )
+
     config = get_config()
-    names = args.checks if args.checks else None
-    results = run_checks(config, names)
 
-    if args.json:
-        print(format_json(results))
+    names: Optional[List[str]] = None
+    groups: Optional[List[str]] = None
+
+    if args.platform:
+        groups = ["platform"]
+    elif args.application:
+        groups = ["application"]
+    elif args.checks:
+        names = args.checks
+
+    results = run_checks(config, names=names, groups=groups)
+
+    use_json = args.json or args.output is not None
+    output = format_json(results) if use_json else format_human(results)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+            f.write("\n")
+
+    if args.output:
+        print(f"Report written to {args.output}")
     else:
-        print(format_human(results))
+        print(output)
 
-    all_pass = results["infrastructure_pass"] and results["quota_pass"]
-    sys.exit(0 if all_pass else 1)
+    overall = results.get("platform_pass", True) and results.get(
+        "infrastructure_pass", True
+    )
+    sys.exit(0 if overall else 1)
 
 
 if __name__ == "__main__":

--- a/backend/verify_ui.py
+++ b/backend/verify_ui.py
@@ -1,0 +1,1592 @@
+"""
+UI verification for Alma — verifies that the frontend correctly
+represents every response lifecycle phase for every mode.
+
+Records raw response shapes, precise timing, and streaming
+behaviour from backend endpoints.  Optionally runs browser-based
+checks via Playwright and captures evidence to verify-output/.
+
+Usage:
+    python -m backend.verify_ui                          # all checks
+    python -m backend.verify_ui --capabilities           # backend probe only
+    python -m backend.verify_ui --static                 # frontend code analysis only
+    python -m backend.verify_ui --browser                # browser-based (requires playwright)
+    python -m backend.verify_ui --json                   # machine-readable
+    python -m backend.verify_ui canvas thinking          # specific modes
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+_TIMEOUT: int = 60
+
+VERIFY_OUTPUT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "verify-output"
+)
+
+
+def _ensure_output_dir() -> str:
+    os.makedirs(VERIFY_OUTPUT, exist_ok=True)
+    return VERIFY_OUTPUT
+
+
+# ── Models ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Timing:
+    """Precise timing for a backend request."""
+
+    request_start: float = 0.0
+    first_byte: float = 0.0
+    last_byte: float = 0.0
+    parsed: float = 0.0
+
+    @property
+    def total_s(self) -> float:
+        return round(self.last_byte - self.request_start, 3)
+
+    @property
+    def ttfb_s(self) -> float:
+        return round(self.first_byte - self.request_start, 3)
+
+    @property
+    def transfer_s(self) -> float:
+        return round(self.last_byte - self.first_byte, 3)
+
+    def to_dict(self) -> dict:
+        return {
+            "total_s": self.total_s,
+            "ttfb_s": self.ttfb_s,
+            "transfer_s": self.transfer_s,
+        }
+
+
+@dataclass
+class StreamingDetection:
+    """How streaming was detected (or not)."""
+
+    method: str = "none"  # sse, chunked, incremental_json, multipart, none
+    evidence: str = ""
+
+
+@dataclass
+class Capability:
+    """What a mode's backend endpoint supports."""
+
+    streaming: bool = False
+    streaming_detection: StreamingDetection = field(default_factory=StreamingDetection)
+    incremental_reasoning: bool = False
+    partial_text: bool = False
+    final_only: bool = True
+    content_type: str = ""
+    response_keys: List[str] = field(default_factory=list)
+    timing: Timing = field(default_factory=Timing)
+
+
+@dataclass
+class ModeCapabilities:
+    """Capability report for a single mode."""
+
+    name: str
+    label: str
+    endpoint: str
+    backend: Capability = field(default_factory=Capability)
+    response_shape_file: str = ""
+    error: Optional[str] = None
+
+
+@dataclass
+class LifecyclePhase:
+    """A single phase in the response lifecycle."""
+
+    name: str
+    label: str
+    present: bool
+    detail: str = ""
+
+
+@dataclass
+class ModeLifecycle:
+    """Lifecycle analysis for a single mode."""
+
+    name: str
+    label: str
+    phases: List[LifecyclePhase] = field(default_factory=list)
+
+
+@dataclass
+class UICheck:
+    """Result of a single UI compliance check."""
+
+    name: str
+    label: str
+    status: str  # pass, fail, skip
+    detail: str = ""
+    category: str = ""
+
+
+@dataclass
+class UIVerificationReport:
+    """Complete report for a single mode."""
+
+    mode: str
+    capabilities: ModeCapabilities
+    lifecycle: ModeLifecycle
+    ui_checks: List[UICheck] = field(default_factory=list)
+    summary_status: str = "pass"
+
+
+@dataclass
+class OverallReport:
+    """Top-level verification report."""
+
+    modes: Dict[str, UIVerificationReport] = field(default_factory=dict)
+    summary: Dict[str, Any] = field(default_factory=dict)
+
+
+# ── Config ────────────────────────────────────────────────────────────
+
+
+def get_config() -> Dict[str, str]:
+    base_url = os.environ.get("ALMA_BASE_URL", "http://localhost:5000").rstrip("/")
+    return {"base_url": base_url}
+
+
+# ── Timing-aware API client ──────────────────────────────────────────
+
+
+@dataclass
+class TimedResponse:
+    status: int
+    body: Any
+    headers: Dict[str, str]
+    timing: Timing
+    raw_body: bytes
+
+
+def api_post_timed(url: str, payload: dict) -> TimedResponse:
+    """POST to *url* and record precise timing for every phase."""
+    timing = Timing()
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    timing.request_start = time.monotonic()
+
+    try:
+        resp = urllib.request.urlopen(req, timeout=_TIMEOUT)
+        timing.first_byte = time.monotonic()
+        raw = resp.read()
+        timing.last_byte = time.monotonic()
+        content_type = resp.headers.get("Content-Type", "")
+        headers = dict(resp.headers)
+
+        if "application/json" in content_type:
+            body = json.loads(raw.decode("utf-8"))
+        else:
+            body = raw
+        timing.parsed = time.monotonic()
+
+        return TimedResponse(
+            status=resp.status,
+            body=body,
+            headers=headers,
+            timing=timing,
+            raw_body=raw,
+        )
+    except urllib.error.HTTPError as e:
+        timing.first_byte = time.monotonic()
+        raw = e.read()
+        timing.last_byte = time.monotonic()
+        try:
+            parsed = json.loads(raw.decode("utf-8"))
+            return TimedResponse(
+                status=e.code,
+                body=parsed,
+                headers=dict(e.headers),
+                timing=timing,
+                raw_body=raw,
+            )
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return TimedResponse(
+                status=e.code,
+                body=raw.decode("utf-8", errors="replace"),
+                headers=dict(e.headers),
+                timing=timing,
+                raw_body=raw,
+            )
+    except urllib.error.URLError as e:
+        timing.last_byte = time.monotonic()
+        return TimedResponse(
+            status=0,
+            body=f"Connection error: {e.reason}",
+            headers={},
+            timing=timing,
+            raw_body=b"",
+        )
+
+
+# ── Streaming detection ──────────────────────────────────────────────
+
+
+def detect_streaming(tresp: TimedResponse) -> Tuple[bool, StreamingDetection]:
+    """Inspect the response headers and body for any streaming capability.
+
+    Checks (in order):
+      1. Content-Type: text/event-stream           (SSE)
+      2. Transfer-Encoding: chunked                (chunked HTTP)
+      3. Body contains multiple JSON objects        (incremental JSON)
+      4. Content-Type: multipart/*                  (multipart)
+    """
+    ct = tresp.headers.get("Content-Type", "").lower()
+    te = tresp.headers.get("Transfer-Encoding", "").lower()
+
+    # 1. SSE
+    if "text/event-stream" in ct:
+        return True, StreamingDetection("sse", "Content-Type: text/event-stream")
+
+    # 2. Chunked
+    if "chunked" in te:
+        return True, StreamingDetection("chunked", "Transfer-Encoding: chunked")
+
+    # 3. Multipart
+    if "multipart/" in ct:
+        return True, StreamingDetection("multipart", f"Content-Type: {ct}")
+
+    # 4. Incremental JSON — multiple top-level JSON objects in a single
+    #    response body (non-streaming endpoints won't have this).
+    if isinstance(tresp.body, dict):
+        pass  # single JSON object, not streaming
+    elif isinstance(tresp.body, str):
+        pass
+    else:
+        body_str = tresp.raw_body.decode("utf-8", errors="replace")
+        trimmed = body_str.strip()
+        # Count how many distinct JSON values appear at the top level
+        # by attempting sequential parses.
+        count = 0
+        pos = 0
+        while pos < len(trimmed):
+            try:
+                _, end = json.JSONDecoder().raw_decode(trimmed, pos)
+                count += 1
+                pos = end
+                # Skip whitespace between objects
+                while pos < len(trimmed) and trimmed[pos] in " \t\n\r":
+                    pos += 1
+            except (json.JSONDecodeError, ValueError):
+                break
+        if count > 1:
+            return True, StreamingDetection(
+                "incremental_json",
+                f"Body contains {count} top-level JSON objects",
+            )
+
+    return False, StreamingDetection("none", "Standard HTTP response")
+
+
+# ── Response shape recorder ──────────────────────────────────────────
+
+
+def _redact_sensitive(obj: Any, depth: int = 0) -> Any:
+    """Replace sensitive fields with '[REDACTED]' recursively."""
+    if depth > 10:
+        return "[MAX_DEPTH]"
+    sensitive_keys = {"api_key", "secret", "password", "token", "auth", "key"}
+    if isinstance(obj, dict):
+        return {
+            k: (
+                "[REDACTED]"
+                if k.lower() in sensitive_keys
+                else _redact_sensitive(v, depth + 1)
+            )
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact_sensitive(v, depth + 1) for v in obj[:100]]
+    if isinstance(obj, bytes):
+        return f"[bytes {len(obj)}]"
+    return obj
+
+
+def save_response_shape(
+    name: str,
+    tresp: TimedResponse,
+) -> str:
+    """Save the raw API response (redacted) to verify-output/."""
+    output_dir = _ensure_output_dir()
+    filename = f"{name}-response.json"
+    filepath = os.path.join(output_dir, filename)
+
+    # Add reasoning metadata for thinking mode
+    reasoning: Dict[str, Any] = {}
+    if name == "thinking" and isinstance(tresp.body, dict):
+        thinking_summary = tresp.body.get("thinking_summary", [])
+        reasoning = {
+            "has_thinking_summary": "thinking_summary" in tresp.body,
+            "thinking_part_count": len(thinking_summary),
+            "thinking_total_chars": sum(len(t) for t in thinking_summary),
+            "has_response": "response" in tresp.body,
+        }
+
+    shape = {
+        "mode": name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": tresp.status,
+        "content_type": tresp.headers.get("Content-Type", ""),
+        "timing": tresp.timing.to_dict(),
+        "headers": _redact_sensitive(dict(tresp.headers)),
+        "response": _redact_sensitive(tresp.body),
+    }
+    if reasoning:
+        shape["reasoning_metadata"] = reasoning
+
+    with open(filepath, "w") as f:
+        json.dump(shape, f, indent=2, default=str)
+        f.write("\n")
+
+    return filepath
+
+
+# ── Backend capability detection ─────────────────────────────────────
+
+
+def detect_capabilities(config: Dict[str, str]) -> Dict[str, ModeCapabilities]:
+    """Probe every backend endpoint and record timing + shape."""
+    base = config["base_url"]
+    modes: List[Tuple[str, str, str, dict]] = [
+        (
+            "canvas",
+            "Canvas",
+            f"{base}/api/generate",
+            {"prompt": "Say hello in one word."},
+        ),
+        (
+            "thinking",
+            "Thinking",
+            f"{base}/api/generate-with-thinking",
+            {"prompt": "What is 2+2?"},
+        ),
+        ("web", "Web", f"{base}/api/generate-with-url-context", {"prompt": "Hi"}),
+        ("images", "Images", f"{base}/api/generate-image", {"prompt": "A red circle"}),
+    ]
+
+    results: Dict[str, ModeCapabilities] = {}
+
+    for name, label, url, payload in modes:
+        cap = ModeCapabilities(name=name, label=label, endpoint=url)
+
+        tresp = api_post_timed(url, payload)
+        cap.backend.timing = tresp.timing
+
+        # Save raw response shape
+        shape_file = save_response_shape(name, tresp)
+        cap.response_shape_file = shape_file
+
+        if tresp.status != 200:
+            cap.error = f"HTTP {tresp.status}"
+            if isinstance(tresp.body, str):
+                cap.error += f": {tresp.body[:200]}"
+            results[name] = cap
+            continue
+
+        # Detect streaming from the actual response
+        is_streaming, detection = detect_streaming(tresp)
+        cap.backend.streaming = is_streaming
+        cap.backend.streaming_detection = detection
+        cap.backend.content_type = tresp.headers.get("Content-Type", "")
+
+        if not is_streaming:
+            cap.backend.final_only = True
+
+        # Inspect response shape
+        if isinstance(tresp.body, dict):
+            cap.backend.response_keys = list(tresp.body.keys())
+            if "thinking_summary" in tresp.body or "reasoning" in tresp.body:
+                cap.backend.incremental_reasoning = False
+            if "response" in tresp.body or "processed_text" in tresp.body:
+                cap.backend.partial_text = is_streaming
+
+        results[name] = cap
+
+    return results
+
+
+# ── Response lifecycle analysis ──────────────────────────────────────
+
+
+def analyze_lifecycle(
+    config: Dict[str, str],
+    capabilities: Dict[str, ModeCapabilities],
+) -> Dict[str, ModeLifecycle]:
+    modes: Dict[str, ModeLifecycle] = {}
+
+    for name in ("canvas", "thinking", "web", "images"):
+        cap = capabilities.get(name)
+        phases = []
+
+        phases.append(
+            LifecyclePhase(
+                name="idle",
+                label="Idle",
+                present=True,
+                detail="Application starts in idle state before any prompt.",
+            )
+        )
+        phases.append(
+            LifecyclePhase(
+                name="request_sent",
+                label="Request sent",
+                present=True,
+                detail="POST request is sent to backend API endpoint.",
+            )
+        )
+
+        if cap and cap.error:
+            phases.append(
+                LifecyclePhase(
+                    name="loading",
+                    label="Loading state",
+                    present=False,
+                    detail=f"Backend returned error: {cap.error}",
+                )
+            )
+        else:
+            phases.append(
+                LifecyclePhase(
+                    name="loading",
+                    label="Loading state",
+                    present=True,
+                    detail="LoadingDots component is shown while waiting.",
+                )
+            )
+
+        is_streaming = cap and cap.backend.streaming
+        detection = cap.backend.streaming_detection if cap else None
+        detail = (
+            f"Backend streams response chunks ({detection.method}: {detection.evidence})."
+            if is_streaming
+            else "Backend returns final response only; no streaming."
+        )
+        phases.append(
+            LifecyclePhase(
+                name="streaming",
+                label="Streaming",
+                present=bool(is_streaming),
+                detail=detail,
+            )
+        )
+        phases.append(
+            LifecyclePhase(
+                name="partial_updates",
+                label="Partial updates",
+                present=bool(is_streaming),
+                detail=(
+                    "UI updates progressively as chunks arrive."
+                    if is_streaming
+                    else "All content appears at once on completion."
+                ),
+            )
+        )
+        phases.append(
+            LifecyclePhase(
+                name="completed",
+                label="Completed",
+                present=True,
+                detail="Response is fully rendered after loading completes.",
+            )
+        )
+        phases.append(
+            LifecyclePhase(
+                name="final_rendered",
+                label="Final rendered state",
+                present=True,
+                detail=(
+                    "Markdown, code blocks, citations, and images render correctly."
+                    if name != "images"
+                    else "Generated image displays in ImageContainer with download link."
+                ),
+            )
+        )
+
+        timing = cap.backend.timing if cap else Timing()
+        phases.append(
+            LifecyclePhase(
+                name="timing",
+                label="Timing",
+                present=True,
+                detail=(
+                    f"TTFB: {timing.ttfb_s}s, "
+                    f"Transfer: {timing.transfer_s}s, "
+                    f"Total: {timing.total_s}s"
+                ),
+            )
+        )
+
+        modes[name] = ModeLifecycle(
+            name=name,
+            label=cap.label if cap else name,
+            phases=phases,
+        )
+
+    return modes
+
+
+# ── Static frontend code analysis ────────────────────────────────────
+
+
+FRONTEND_SRC = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "frontend",
+    "src",
+)
+
+
+def read_frontend_file(path: str) -> Optional[str]:
+    full = os.path.join(FRONTEND_SRC, path)
+    if os.path.isfile(full):
+        with open(full) as f:
+            return f.read()
+    return None
+
+
+def check_thinking_completeness() -> UICheck:
+    """Validate that the UI renders every reasoning field the backend returns.
+
+    The backend returns ``thinking_summary`` (array of thought texts) and
+    ``response`` (final answer).  The frontend must display both.
+    """
+    hook_code = read_frontend_file("hooks/useConversation.ts")
+    app_code = read_frontend_file("App.tsx")
+    types_code = read_frontend_file("types/index.ts")
+
+    if not hook_code:
+        return UICheck(
+            "thinking_completeness",
+            "Thinking renders all reasoning fields",
+            "fail",
+            "useConversation.ts not found",
+        )
+
+    # Frontend must read both response and thinking_summary from API
+    reads_response = "result.response" in hook_code or "result?.response" in hook_code
+    reads_thinking = (
+        "result.thinking_summary" in hook_code
+        or "result?.thinking_summary" in hook_code
+    )
+
+    # Frontend must have separate state for both
+    has_response_state = "response" in hook_code and "setResponse" in hook_code
+    has_thinking_state = "thinking" in hook_code and "setThinking" in hook_code
+
+    # Frontend must render both
+    renders_thinking = (
+        app_code and "ThinkingContainer" in app_code and "thinking &&" in app_code
+    )
+    renders_response = (
+        app_code and "ResponseContainer" in app_code and "response &&" in app_code
+    )
+
+    # Type must include thinking_summary
+    has_thinking_type = types_code and "thinking_summary" in types_code
+
+    missing = []
+    if not reads_thinking:
+        missing.append("reads thinking_summary from API")
+    if not reads_response:
+        missing.append("reads response from API")
+    if not has_thinking_state:
+        missing.append("has thinking state variable")
+    if not has_response_state:
+        missing.append("has response state variable")
+    if not renders_thinking:
+        missing.append("renders ThinkingContainer")
+    if not renders_response:
+        missing.append("renders ResponseContainer")
+    if not has_thinking_type:
+        missing.append("thinking_summary in ApiThinkingResult type")
+
+    if not missing:
+        return UICheck(
+            "thinking_completeness",
+            "Thinking renders all reasoning fields",
+            "pass",
+            "All thinking fields (thinking_summary, response) are read from API "
+            "and rendered separately. No data is silently discarded.",
+        )
+    return UICheck(
+        "thinking_completeness",
+        "Thinking renders all reasoning fields",
+        "fail",
+        f"Missing: {', '.join(missing)}",
+    )
+
+
+def check_has_loading_indicator() -> UICheck:
+    code = read_frontend_file("components/LoadingDots.tsx")
+    app_code = read_frontend_file("App.tsx")
+    if not code:
+        return UICheck(
+            "loading_component",
+            "Loading indicator exists",
+            "fail",
+            "LoadingDots.tsx not found",
+        )
+    has_export = (
+        "export default function LoadingDots" in code
+        or "export const LoadingDots" in code
+        or "export default LoadingDots" in code
+    )
+    has_label_prop = "label" in code
+    used_in_app = app_code and "LoadingDots" in app_code
+    if has_export and has_label_prop and used_in_app:
+        return UICheck(
+            "loading_component",
+            "Loading indicator exists",
+            "pass",
+            "LoadingDots component is defined with label prop and used in App.tsx",
+        )
+    missing = []
+    if not has_export:
+        missing.append("export")
+    if not has_label_prop:
+        missing.append("label prop")
+    if not used_in_app:
+        missing.append("usage in App.tsx")
+    return UICheck(
+        "loading_component",
+        "Loading indicator exists",
+        "fail",
+        f"Missing: {', '.join(missing)}",
+    )
+
+
+def check_has_thinking_display() -> UICheck:
+    code = read_frontend_file("components/ThinkingContainer.tsx")
+    app_code = read_frontend_file("App.tsx")
+    hook_code = read_frontend_file("hooks/useConversation.ts")
+    if not code:
+        return UICheck(
+            "thinking_display",
+            "Thinking display",
+            "fail",
+            "ThinkingContainer.tsx not found",
+        )
+    has_thinking_separator = "thinking" in code
+    separate_state = hook_code and "setThinking" in hook_code
+    separate_render = app_code and "thinking &&" in app_code
+    if all([has_thinking_separator, separate_state, separate_render]):
+        return UICheck(
+            "thinking_display",
+            "Thinking display",
+            "pass",
+            "Thinking displayed in separate container with distinct styling; "
+            "state and rendering are independent from response.",
+        )
+    missing = []
+    if not has_thinking_separator:
+        missing.append("thinking content")
+    if not separate_render:
+        missing.append("separate render path")
+    return UICheck(
+        "thinking_display", "Thinking display", "fail", f"Missing: {', '.join(missing)}"
+    )
+
+
+def check_response_rendering() -> UICheck:
+    code = read_frontend_file("components/ResponseContainer.tsx")
+    if not code:
+        return UICheck(
+            "response_markdown",
+            "Markdown rendering",
+            "fail",
+            "ResponseContainer.tsx not found",
+        )
+    has_react_markdown = "react-markdown" in code
+    has_remark_gfm = "remark-gfm" in code or "remarkGfm" in code or "remark_gfm" in code
+    if has_react_markdown and has_remark_gfm:
+        return UICheck(
+            "response_markdown",
+            "Markdown rendering",
+            "pass",
+            "Responses render via react-markdown with GFM (code blocks, tables, lists).",
+        )
+    elif has_react_markdown:
+        return UICheck(
+            "response_markdown",
+            "Markdown rendering",
+            "pass",
+            "Responses render via react-markdown (no GFM detected).",
+        )
+    return UICheck(
+        "response_markdown",
+        "Markdown rendering",
+        "fail",
+        "No react-markdown usage found.",
+    )
+
+
+def check_code_blocks() -> UICheck:
+    code = read_frontend_file("components/ResponseContainer.tsx")
+    css = read_frontend_file("index.css")
+    if not code:
+        return UICheck(
+            "code_blocks",
+            "Code block styling",
+            "fail",
+            "ResponseContainer.tsx not found",
+        )
+    has_inline = "inline" in code and ("code" in code)
+    has_pre = "pre" in code
+    has_code_styles = css and ("code" in css and "pre" in css)
+    if has_inline and has_pre:
+        return UICheck(
+            "code_blocks",
+            "Code block styling",
+            "pass",
+            "Inline code and code blocks have distinct styling.",
+        )
+    elif has_code_styles:
+        return UICheck(
+            "code_blocks",
+            "Code block styling",
+            "pass",
+            "Code block styles defined in CSS.",
+        )
+    return UICheck(
+        "code_blocks",
+        "Code block styling",
+        "fail",
+        "No distinct code block styling detected.",
+    )
+
+
+def check_image_display() -> UICheck:
+    code = read_frontend_file("components/ImageContainer.tsx")
+    app_code = read_frontend_file("App.tsx")
+    if not code:
+        return UICheck(
+            "image_display", "Image display", "fail", "ImageContainer.tsx not found"
+        )
+    has_img_tag = "<img" in code
+    has_save_link = "Save" in code or "download" in code
+    has_null_guard = "return null" in code
+    used_in_app = app_code and "ImageContainer" in app_code
+    if has_img_tag and has_null_guard and used_in_app:
+        detail = "Image displays in dedicated ImageContainer with null guard."
+        if has_save_link:
+            detail += " Includes download/save link."
+        return UICheck("image_display", "Image display", "pass", detail)
+    return UICheck(
+        "image_display", "Image display", "fail", "Image rendering is incomplete."
+    )
+
+
+def check_mode_routing() -> UICheck:
+    hook_code = read_frontend_file("hooks/useConversation.ts")
+    if not hook_code:
+        return UICheck(
+            "mode_routing", "Mode routing", "fail", "useConversation.ts not found"
+        )
+    has_canvas = "mode === 'canvas'" in hook_code or "mode === canvas" in hook_code
+    has_thinking = "mode === 'thinking'" in hook_code
+    has_web = "mode === 'web'" in hook_code
+    has_images = "mode === 'images'" in hook_code
+    has_else_canvas = has_thinking and has_web and has_images and not has_canvas
+    if has_else_canvas:
+        has_canvas = True
+    canvas_mode = "canvas (default, else branch)" if has_else_canvas else "canvas"
+    missing = []
+    if not has_canvas:
+        missing.append("canvas")
+    if not has_thinking:
+        missing.append("thinking")
+    if not has_web:
+        missing.append("web")
+    if not has_images:
+        missing.append("images")
+    status = "pass" if not missing else "fail"
+    detail = (
+        f"All modes routed: {canvas_mode}, thinking, web, images."
+        if not missing
+        else f"Missing routes: {', '.join(missing)}"
+    )
+    return UICheck("mode_routing", "Mode routing", status, detail)
+
+
+def check_conversation_started_transition() -> UICheck:
+    code = read_frontend_file("App.tsx")
+    if not code:
+        return UICheck(
+            "conversation_transition",
+            "Conversation layout transition",
+            "fail",
+            "App.tsx not found",
+        )
+    has_transition = "conversationStarted" in code
+    has_landing = "LandingLayout" in code
+    has_conversation = "ConversationLayout" in code
+    if has_transition and has_landing and has_conversation:
+        return UICheck(
+            "conversation_transition",
+            "Conversation layout transition",
+            "pass",
+            "App.tsx conditionally renders LandingLayout or ConversationLayout "
+            "based on conversationStarted flag.",
+        )
+    return UICheck(
+        "conversation_transition",
+        "Conversation layout transition",
+        "fail",
+        "Landing-to-conversation transition not found.",
+    )
+
+
+def check_composer_input_states() -> UICheck:
+    code = read_frontend_file("components/Composer.tsx")
+    if not code:
+        return UICheck(
+            "composer_states", "Composer input states", "fail", "Composer.tsx not found"
+        )
+    has_loading_bar = "loading-bar" in code or "composer-loading-bar" in code
+    has_disabled = "disabled" in code or "readOnly" in code
+    checks = []
+    if has_loading_bar:
+        checks.append("loading bar")
+    if has_disabled:
+        checks.append("disabled state during loading")
+    if checks:
+        return UICheck(
+            "composer_states",
+            "Composer input states",
+            "pass",
+            f"Composer shows: {', '.join(checks)} while loading.",
+        )
+    return UICheck(
+        "composer_states",
+        "Composer input states",
+        "fail",
+        "No loading state indicators found in Composer.",
+    )
+
+
+def run_static_checks() -> List[UICheck]:
+    return [
+        check_has_loading_indicator(),
+        check_has_thinking_display(),
+        check_thinking_completeness(),
+        check_response_rendering(),
+        check_code_blocks(),
+        check_image_display(),
+        check_mode_routing(),
+        check_conversation_started_transition(),
+        check_composer_input_states(),
+    ]
+
+
+# ── Report generation ────────────────────────────────────────────────
+
+
+def check_backend_ui_alignment(mode: str, cap: ModeCapabilities) -> UICheck:
+    label = "Backend-UI alignment"
+    name = "alignment"
+    if mode == "thinking":
+        keys = cap.backend.response_keys
+        has_response = "response" in keys
+        has_thinking_summary = "thinking_summary" in keys
+        missing_keys = []
+        if not has_response:
+            missing_keys.append("response")
+        if not has_thinking_summary:
+            missing_keys.append("thinking_summary")
+
+        if missing_keys:
+            return UICheck(
+                name,
+                label,
+                "fail",
+                f"Backend response missing expected keys: {', '.join(missing_keys)}. "
+                f"Got: {', '.join(keys)}",
+            )
+
+        if cap.backend.final_only and not cap.backend.incremental_reasoning:
+            return UICheck(
+                name,
+                label,
+                "pass",
+                f"Backend returns {len(keys)} fields ({', '.join(keys)}). "
+                "All reasoning content is in thinking_summary. "
+                "UI correctly waits for completion, then displays "
+                "thinking and response separately. No data discarded.",
+            )
+        if cap.backend.streaming:
+            return UICheck(
+                name,
+                label,
+                "fail",
+                "Backend streams reasoning, but UI waits for full response "
+                "before displaying. Should render chunks incrementally.",
+            )
+    elif mode == "images":
+        return UICheck(
+            name,
+            label,
+            "pass",
+            "Backend returns complete image. UI displays ImageContainer "
+            "with null guard on load.",
+        )
+    else:
+        if cap.backend.final_only:
+            return UICheck(
+                name,
+                label,
+                "pass",
+                "Backend returns final response only. UI displays loading "
+                "indicator until completion, then renders markdown.",
+            )
+        if cap.backend.streaming:
+            return UICheck(
+                name,
+                label,
+                "fail",
+                "Backend streams, but UI should render chunks progressively.",
+            )
+    return UICheck(name, label, "pass", "UI behavior matches backend capabilities.")
+
+
+def generate_overall_report(
+    config: Dict[str, str],
+    capabilities: Dict[str, ModeCapabilities],
+    static_checks: List[UICheck],
+) -> OverallReport:
+    lifecycles = analyze_lifecycle(config, capabilities)
+    report = OverallReport()
+
+    for name in ("canvas", "thinking", "web", "images"):
+        cap = capabilities.get(name)
+        lc = lifecycles.get(name)
+        if not cap or not lc:
+            continue
+
+        mode_checks: List[UICheck] = []
+        for c in static_checks:
+            if name == "images" and c.name in ("thinking_display", "code_blocks"):
+                sk = UICheck(
+                    name=c.name,
+                    label=c.label,
+                    status="skip",
+                    detail="Not applicable for image mode.",
+                )
+                mode_checks.append(sk)
+                continue
+            if name != "images" and c.name == "image_display":
+                mode_checks.append(
+                    UICheck(
+                        name="image_display",
+                        label="Image display",
+                        status="skip",
+                        detail="Not applicable for text-based mode.",
+                    )
+                )
+                continue
+            mode_checks.append(c)
+
+        mode_checks.append(check_backend_ui_alignment(name, cap))
+
+        failures = [c for c in mode_checks if c.status == "fail"]
+        report.modes[name] = UIVerificationReport(
+            mode=name,
+            capabilities=cap,
+            lifecycle=lc,
+            ui_checks=mode_checks,
+            summary_status="pass" if not failures else "fail",
+        )
+
+    all_pass = all(r.summary_status == "pass" for r in report.modes.values())
+    bc = {}
+    for m, c in capabilities.items():
+        bc[m] = {
+            "streaming": c.backend.streaming,
+            "streaming_detection": asdict(c.backend.streaming_detection),
+            "incremental_reasoning": c.backend.incremental_reasoning,
+            "partial_text": c.backend.partial_text,
+            "final_only": c.backend.final_only,
+            "timing": c.backend.timing.to_dict(),
+        }
+    ui_pass = sum(
+        1 for r in report.modes.values() for c in r.ui_checks if c.status == "pass"
+    )
+    ui_total = sum(
+        1 for r in report.modes.values() for c in r.ui_checks if c.status != "skip"
+    )
+
+    report.summary = {
+        "overall": "pass" if all_pass else "fail",
+        "backend_capabilities": bc,
+        "ui_checks_passed": f"{ui_pass}/{ui_total}",
+        "modes_verified": list(report.modes.keys()),
+        "output_dir": _ensure_output_dir(),
+    }
+    return report
+
+
+# ── Browser verifier (Playwright) ────────────────────────────────────
+
+
+def check_playwright_installed() -> bool:
+    """Check if Playwright is available."""
+    try:
+        import playwright  # noqa
+
+        return True
+    except ImportError:
+        return False
+
+
+def run_browser_verification(output_dir: str, modes: List[str]) -> List[UICheck]:
+    """Run Playwright-based browser verification."""
+    if not check_playwright_installed():
+        return [
+            UICheck(
+                "playwright",
+                "Playwright",
+                "fail",
+                "Playwright not installed. Run: pip install playwright && playwright install chromium",
+            )
+        ]
+
+    from playwright.sync_api import sync_playwright
+
+    results: List[UICheck] = []
+    base_url = os.environ.get("ALMA_FRONTEND_URL", "http://localhost:5173")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            viewport={"width": 1280, "height": 800},
+            record_har_path=(
+                os.path.join(output_dir, "network.har") if output_dir else None
+            ),
+        )
+        page = context.new_page()
+
+        # Collect console logs
+        console_logs: List[str] = []
+        page.on("console", lambda msg: console_logs.append(f"[{msg.type}] {msg.text}"))
+        page.on("pageerror", lambda err: console_logs.append(f"[ERROR] {err}"))
+
+        def screenshot(name: str) -> None:
+            path = os.path.join(output_dir, f"{name}.png")
+            page.screenshot(path=path, full_page=True)
+            results.append(
+                UICheck(f"screenshot_{name}", f"Screenshot: {name}", "pass", path)
+            )
+
+        try:
+            # Landing page
+            page.goto(base_url, wait_until="networkidle", timeout=_TIMEOUT * 1000)
+            screenshot("landing")
+            results.append(
+                UICheck(
+                    "landing",
+                    "Landing page loads",
+                    "pass",
+                    f"{base_url} loaded successfully.",
+                )
+            )
+
+            # Theme toggle
+            theme_btn = page.locator("button[aria-label*='theme']")
+            if theme_btn.count():
+                theme_btn.click()
+                page.wait_for_timeout(500)
+                screenshot("theme-toggled")
+                results.append(UICheck("theme_toggle", "Theme toggle works", "pass"))
+            else:
+                results.append(
+                    UICheck(
+                        "theme_toggle",
+                        "Theme toggle works",
+                        "skip",
+                        "Theme toggle button not found.",
+                    )
+                )
+
+            # Sidebar
+            menu_btn = page.locator(
+                "button[aria-label*='menu'], .header-menu-btn, button:has(svg)"
+            )
+            if menu_btn.count():
+                menu_btn.first.click()
+                page.wait_for_timeout(500)
+                screenshot("sidebar")
+                results.append(UICheck("sidebar", "Sidebar opens", "pass"))
+                page.keyboard.press("Escape")
+                page.wait_for_timeout(300)
+            else:
+                results.append(
+                    UICheck(
+                        "sidebar", "Sidebar opens", "skip", "Menu button not found."
+                    )
+                )
+
+            # Keyboard shortcut
+            page.keyboard.press("Meta+n")
+            page.wait_for_timeout(500)
+            results.append(
+                UICheck(
+                    "keyboard_shortcut",
+                    "Keyboard shortcut (Cmd+N)",
+                    "pass",
+                    "Cmd+N triggered without error.",
+                )
+            )
+
+            # Mode-specific checks
+            mode_labels = {
+                "canvas": "Canvas",
+                "thinking": "Thinking",
+                "web": "Web",
+                "images": "Images",
+            }
+            for mode_name in modes:
+                label = mode_labels.get(mode_name, mode_name)
+
+                # Click mode segment
+                seg = page.locator(
+                    f"button:has-text('{label}'), [role='tab']:has-text('{label}')"
+                )
+                if seg.count():
+                    seg.first.click()
+                    page.wait_for_timeout(300)
+
+                # Type a prompt
+                input_box = page.locator(
+                    "textarea, input[type='text'], [contenteditable='true']"
+                )
+                if input_box.count():
+                    input_box.first.fill(f"Say hello in one word for {label} mode.")
+                    page.wait_for_timeout(200)
+
+                    # Submit — look for send button or Enter
+                    send_btn = page.locator(
+                        "button[aria-label*='send'], button:has(svg):not([aria-label*='menu'])"
+                    )
+                    if send_btn.count():
+                        send_btn.first.click()
+                    else:
+                        page.keyboard.press("Enter")
+
+                    # Wait briefly and capture loading state
+                    page.wait_for_timeout(1000)
+                    screenshot(f"{mode_name}-loading")
+
+                    # Wait for response to complete
+                    page.wait_for_timeout(8000)
+                    screenshot(f"{mode_name}-response")
+
+                    results.append(
+                        UICheck(
+                            f"{mode_name}_submission",
+                            f"{label} submission",
+                            "pass",
+                            f"{label} mode submitted and response captured.",
+                        )
+                    )
+                else:
+                    results.append(
+                        UICheck(
+                            f"{mode_name}_submission",
+                            f"{label} submission",
+                            "fail",
+                            "Input field not found.",
+                        )
+                    )
+
+            # New conversation flow
+            if "New conversation" in page.content():
+                new_chat = page.locator("button:has-text('New conversation')")
+                if new_chat.count():
+                    try:
+                        new_chat.first.click(timeout=5000)
+                        page.wait_for_timeout(500)
+                        screenshot("new-conversation")
+                        results.append(
+                            UICheck("new_conversation", "New conversation flow", "pass")
+                        )
+                    except Exception:
+                        results.append(
+                            UICheck(
+                                "new_conversation",
+                                "New conversation flow",
+                                "skip",
+                                "Button found but outside viewport.",
+                            )
+                        )
+
+            # Save console logs
+            log_path = os.path.join(output_dir, "console.log")
+            with open(log_path, "w") as f:
+                f.write("\n".join(console_logs))
+            if console_logs:
+                errors = [line for line in console_logs if "[ERROR]" in line]
+                if errors:
+                    results.append(
+                        UICheck(
+                            "console_errors",
+                            "Console errors",
+                            "fail",
+                            f"{len(errors)} errors: {'; '.join(errors[:5])}",
+                        )
+                    )
+                else:
+                    results.append(
+                        UICheck(
+                            "console_errors",
+                            "Console errors",
+                            "pass",
+                            f"No errors ({len(console_logs)} log entries).",
+                        )
+                    )
+
+        except Exception as exc:
+            # Save console logs on failure too
+            if console_logs:
+                log_path = os.path.join(output_dir, "console.log")
+                with open(log_path, "w") as f:
+                    f.write("\n".join(console_logs))
+            results.append(
+                UICheck("browser_error", "Browser verification", "fail", str(exc))
+            )
+        finally:
+            context.close()
+            browser.close()
+
+    return results
+
+
+# ── Human-readable output ────────────────────────────────────────────
+
+
+def format_human(report: OverallReport) -> str:
+    lines: List[str] = []
+    lines.append("UI Verification Report")
+    lines.append("")
+
+    for mode_name, ui_report in report.modes.items():
+        cap = ui_report.capabilities
+        lc = ui_report.lifecycle
+        lines.append(f"\u2500\u2500 {cap.label} \u2500\u2500")
+        lines.append("")
+
+        # Backend capabilities
+        lines.append("  Backend")
+        lines.append(f"    Endpoint:  {cap.endpoint}")
+        lines.append(f"    Streaming: {'Yes' if cap.backend.streaming else 'No'}")
+        if cap.backend.streaming:
+            sd = cap.backend.streaming_detection
+            lines.append(f"    Detection: {sd.method} ({sd.evidence})")
+        lines.append(
+            f"    Reasoning: {'Incremental' if cap.backend.incremental_reasoning else 'Final payload only'}"
+        )
+        lines.append(
+            f"    Text:      {'Partial' if cap.backend.partial_text else 'Final-only'}"
+        )
+        keys = cap.backend.response_keys
+        lines.append(f"    Response:  {', '.join(keys) if keys else '(binary)'}")
+
+        t = cap.backend.timing
+        lines.append(
+            f"    Timing:    TTFB {t.ttfb_s}s, Transfer {t.transfer_s}s, Total {t.total_s}s"
+        )
+        if cap.error:
+            lines.append(f"    Error:     {cap.error}")
+        if cap.response_shape_file:
+            lines.append(f"    Shape:     {cap.response_shape_file}")
+        lines.append("")
+
+        # Lifecycle phases
+        lines.append("  Lifecycle")
+        for phase in lc.phases:
+            marker = "\u2713" if phase.present else "\u2717"
+            lines.append(f"    {marker} {phase.label}")
+            lines.append(f"      {phase.detail}")
+        lines.append("")
+
+        # UI checks
+        lines.append("  UI")
+        for check in ui_report.ui_checks:
+            if check.status == "pass":
+                marker = "\u2713"
+            elif check.status == "skip":
+                marker = "\u2014"
+            else:
+                marker = "\u2717"
+            lines.append(f"    {marker} {check.label}")
+            if check.detail:
+                lines.append(f"      {check.detail}")
+        lines.append("")
+        lines.append(f"  Result: {ui_report.summary_status.upper()}")
+        lines.append("")
+
+    # Summary
+    lines.append("Summary")
+    lines.append(f"  Overall: {report.summary.get('overall', 'unknown').upper()}")
+    lines.append(f"  UI checks: {report.summary.get('ui_checks_passed', '?')} passed")
+    lines.append(f"  Output:   {report.summary.get('output_dir', '(none)')}")
+    lines.append("")
+    bc = report.summary.get("backend_capabilities", {})
+    lines.append("Backend capabilities:")
+    for mode, caps in bc.items():
+        label = mode.capitalize()
+        stream = "streaming" if caps.get("streaming") else "final"
+        reason = caps.get("incremental_reasoning", False)
+        r = ", incremental reasoning" if reason else ""
+        timing = caps.get("timing", {})
+        t = f", {timing.get('total_s', '?')}s total"
+        lines.append(f"  {label}: {stream}{r}{t}")
+
+    return "\n".join(lines)
+
+
+def format_json(report: OverallReport) -> str:
+    return json.dumps(asdict(report), indent=2, default=str)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="UI verification for Alma \u2014 validates that the frontend "
+        "correctly represents every response lifecycle phase.",
+    )
+    parser.add_argument(
+        "--capabilities",
+        action="store_true",
+        help="Run backend capability detection only",
+    )
+    parser.add_argument(
+        "--static",
+        action="store_true",
+        help="Run static frontend code analysis only",
+    )
+    parser.add_argument(
+        "--browser",
+        action="store_true",
+        help="Run browser-based verification (requires Playwright)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        metavar="FILE",
+        help="Write JSON report to FILE",
+    )
+    parser.add_argument(
+        "modes",
+        nargs="*",
+        metavar="MODE",
+        default=[],
+        help="Specific modes to verify (default: all)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Timeout in seconds (default: 60)",
+    )
+
+    args = parser.parse_args()
+    global _TIMEOUT
+    _TIMEOUT = args.timeout
+
+    config = get_config()
+    valid_modes = {"canvas", "thinking", "web", "images"}
+    if args.modes:
+        for m in args.modes:
+            if m not in valid_modes:
+                parser.error(
+                    f"unknown mode: {m!r}; choices: {', '.join(sorted(valid_modes))}"
+                )
+
+    output_dir = _ensure_output_dir()
+
+    # ── capabilities-only ──
+    if args.capabilities:
+        capabilities = detect_capabilities(config)
+        if args.modes:
+            capabilities = {k: v for k, v in capabilities.items() if k in args.modes}
+
+        out: Dict[str, Any] = {}
+        for name, cap in capabilities.items():
+            out[name] = {
+                "endpoint": cap.endpoint,
+                "streaming": cap.backend.streaming,
+                "streaming_detection": asdict(cap.backend.streaming_detection),
+                "incremental_reasoning": cap.backend.incremental_reasoning,
+                "partial_text": cap.backend.partial_text,
+                "final_only": cap.backend.final_only,
+                "response_keys": cap.backend.response_keys,
+                "content_type": cap.backend.content_type,
+                "timing": cap.backend.timing.to_dict(),
+                "response_shape_file": cap.response_shape_file,
+            }
+        if args.json or args.output:
+            output = json.dumps(out, indent=2)
+        else:
+            lines = ["Backend capabilities", ""]
+            for name, info in out.items():
+                lines.append(f"  {name.capitalize()}:")
+                lines.append(f"    Endpoint:  {info['endpoint']}")
+                lines.append(f"    Streaming: {'Yes' if info['streaming'] else 'No'}")
+                if info.get("streaming_detection", {}).get("method") != "none":
+                    sd = info["streaming_detection"]
+                    lines.append(f"    Detection: {sd['method']} ({sd['evidence']})")
+                lines.append(
+                    f"    Reasoning: {'Incremental' if info['incremental_reasoning'] else 'Final payload only'}"
+                )
+                lines.append(
+                    f"    Text:      {'Partial' if info['partial_text'] else 'Final-only'}"
+                )
+                lines.append(
+                    f"    Keys:      {', '.join(info['response_keys']) if info['response_keys'] else '(binary)'}"
+                )
+                t = info.get("timing", {})
+                lines.append(
+                    f"    Timing:    TTFB {t.get('ttfb_s', '?')}s, Total {t.get('total_s', '?')}s"
+                )
+                if info.get("response_shape_file"):
+                    lines.append(f"    Shape:     {info['response_shape_file']}")
+                lines.append("")
+            output = "\n".join(lines)
+
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output)
+                f.write("\n")
+        else:
+            print(output)
+        return
+
+    # ── static-only ──
+    if args.static:
+        checks = run_static_checks()
+        if args.json or args.output:
+            output = json.dumps(
+                [
+                    {
+                        "name": c.name,
+                        "label": c.label,
+                        "status": c.status,
+                        "detail": c.detail,
+                    }
+                    for c in checks
+                ],
+                indent=2,
+            )
+        else:
+            lines = ["Static frontend analysis", ""]
+            for c in checks:
+                marker = (
+                    "\u2713"
+                    if c.status == "pass"
+                    else ("\u2014" if c.status == "skip" else "\u2717")
+                )
+                lines.append(f"  {marker} {c.label}: {c.status.upper()}")
+                if c.detail:
+                    lines.append(f"    {c.detail}")
+            lines.append("")
+            output = "\n".join(lines)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output)
+                f.write("\n")
+        else:
+            print(output)
+        return
+
+    # ── browser-only ──
+    if args.browser:
+        browser_modes = args.modes or list(valid_modes)
+        checks = run_browser_verification(output_dir, browser_modes)
+
+        if args.json or args.output:
+            output = json.dumps(
+                [
+                    {
+                        "name": c.name,
+                        "label": c.label,
+                        "status": c.status,
+                        "detail": c.detail,
+                    }
+                    for c in checks
+                ],
+                indent=2,
+            )
+        else:
+            lines = ["Browser verification", ""]
+            for c in checks:
+                marker = (
+                    "\u2713"
+                    if c.status == "pass"
+                    else ("\u2014" if c.status == "skip" else "\u2717")
+                )
+                lines.append(f"  {marker} {c.label}: {c.status.upper()}")
+                if c.detail:
+                    lines.append(f"    {c.detail}")
+            lines.append("")
+            lines.append(f"Evidence saved to: {output_dir}")
+            output = "\n".join(lines)
+
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output)
+                f.write("\n")
+        else:
+            print(output)
+        return
+
+    # ── full UI verification ──
+    capabilities = detect_capabilities(config)
+    if args.modes:
+        capabilities = {k: v for k, v in capabilities.items() if k in args.modes}
+
+    static_checks = run_static_checks()
+    report = generate_overall_report(config, capabilities, static_checks)
+
+    output = format_json(report) if (args.json or args.output) else format_human(report)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+            f.write("\n")
+        if not args.json:
+            print(f"Report written to {args.output}")
+    else:
+        print(output)
+
+    overall = report.summary.get("overall", "fail")
+    sys.exit(0 if overall == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,181 @@
+# Platform Architecture Overview
+
+The application is supported by a platform services layer that owns
+cross-product infrastructure. This document explains the architecture
+at a high level and points to detailed documents for each component.
+
+---
+
+## Layer Model
+
+```
+            ┌──────────────────────────────────┐
+            │          Application              │
+            │  (Alma, Via, Nuntius, Glimpse)   │
+            └────────────┬─────────────────────┘
+                         │
+                    ┌────▼─────┐
+                    │  verify  │  ← one command: platform + application health
+                    └────┬─────┘
+                         │
+            ┌────────────▼──────────────────────┐
+            │        PlatformManager             │
+            │  (services/platform.py)           │
+            │  lazy init · health · shutdown    │
+            └──┬────────┬────────┬────────┬─────┘
+               │        │        │        │
+         ┌─────▼──┐ ┌──▼───┐ ┌──▼────┐ ┌─▼──────────┐
+         │  Mail  │ │ Auth │ │Storage│ │Notifications│
+         │ Service│ │Service│ │Service│ │  Service    │
+         └───┬────┘ └──┬───┘ └──┬────┘ └──────┬──────┘
+             │          │        │              │
+         Provider   Provider  Provider       Channel
+           ABC        ABC       ABC            ABC
+       ┌───┼───┐  ┌───┼───┐ ┌──┼───┐    ┌────┼────┐
+       │   │   │  │   │   │ │  │   │    │    │    │
+     Mock SMTP   Mock JWT  Mock Local  Mock Email Webhook
+          Resend                Cloud
+             │          │        │              │
+             └──────────┴────────┴──────────────┘
+                         │
+              ┌──────────▼──────────┐
+              │    Infrastructure    │
+              │  (SMTP, Resend API, │
+              │   GCS/S3, HTTP)     │
+              └─────────────────────┘
+```
+
+---
+
+## How It Works
+
+### PlatformManager
+
+`backend/services/platform.py` — the single entry point for all platform
+services. Application code never constructs `MailService`, `AuthService`,
+etc. directly.
+
+```python
+from services import platform
+
+platform.mail.send(template, recipient, context)
+platform.auth.login(email, password)
+platform.storage.upload(path, data)
+platform.notifications.send(recipient, subject, body)
+
+health = platform.health()        # all services in one call
+platform.shutdown()               # graceful teardown
+```
+
+Services are lazily initialized from environment variables on first
+access. `platform.health()` returns status for every service, making
+it trivial to expose a single `/api/health` endpoint.
+
+### Platform Services
+
+Each service follows an identical architecture:
+
+- **Config** — `from_env()` reads all settings from environment variables
+- **Provider/Channel ABC** — abstract base class for pluggable backends
+- **Registry** — provider registration and lookup by name
+- **Service** — public API (send, register, upload, health, shutdown)
+- **Metrics** — counters, histograms, snapshots
+- **Logging** — structured audit trail
+- **Verify** — standalone CLI for diagnostics
+
+Provider selection is always configuration-only:
+`MAIL_PROVIDER`, `AUTH_PROVIDER`, `STORAGE_PROVIDER`,
+`NOTIFICATIONS_DEFAULT_CHANNEL`. No code changes required.
+
+### alma verify
+
+`backend/verify.py` — consolidated operational CLI that checks both
+platform services (local) and application endpoints (API).
+
+```bash
+python -m backend.verify                    # all checks
+python -m backend.verify --platform         # platform only
+python -m backend.verify --application      # API only
+python -m backend.verify --json             # machine-readable
+python -m backend.verify --json --output report.json  # write to file
+python -m backend.verify mail auth          # specific services
+```
+
+The exit code is 0 only when all infrastructure checks pass (quota
+issues like image generation rate limits are reported separately and
+do not cause a failure). This makes it suitable for CI gating.
+
+---
+
+## Service Reference
+
+| Service | Path | Public API | Providers |
+|---------|------|------------|-----------|
+| Mail | `backend/services/mail/` | `MailService.send()` | Mock, SMTP, Resend |
+| Auth | `backend/services/auth/` | `register`, `login`, `verify`, `refresh`, `logout` | Mock, JWT |
+| Storage | `backend/services/storage/` | `upload`, `download`, `delete`, `exists`, `metadata`, `list`, `signed_url` | Mock, Local, Cloud |
+| Notifications | `backend/services/notifications/` | `NotificationService.send()` | Mock, Email, Webhook |
+
+---
+
+## Decision Records
+
+| Document | Topic |
+|----------|-------|
+| `docs/architecture/0001-platform-services.md` | Why the platform services layer exists |
+| `docs/architecture/0002-mail-service.md` | Mail as a reusable platform capability |
+| `docs/architecture/0003-auth-service.md` | Auth as a reusable platform capability |
+| `docs/architecture/0003-storage-service.md` | Storage as a reusable platform capability |
+| `docs/architecture/0004-notifications-service.md` | Notifications as a reusable platform capability |
+
+---
+
+## Key Properties
+
+- **Product-agnostic**: Zero references to any specific application.
+  All four services can be extracted into standalone packages without
+  changing consumers.
+
+- **Configuration-driven**: Provider selection, timeouts, limits — all
+  from environment variables. No code changes to switch backends.
+
+- **Mock by default**: Every service defaults to an in-memory mock.
+  Zero credentials required for local development. Same code path as
+  production.
+
+- **Observable by default**: Every service exposes `health()`,
+  `metrics.snapshot()`, and structured logging with consistent field
+  naming.
+
+- **Tested by architecture**: Every service has architecture boundary
+  tests that prevent accidental dependencies on application code or
+  other platform modules.
+
+- **One verify command**: `python -m backend.verify` reports platform
+  health and application endpoint status together. Designed for both
+  human operators and CI.
+
+---
+
+## Versioning
+
+See [docs/versioning.md](versioning.md) for the complete policy on
+public API, breaking changes, and deprecation.
+
+Platform services currently share version 0.1.0.
+
+---
+
+## Out of Scope
+
+The platform layer intentionally does not include:
+
+- **Service discovery** — not needed at single-service scale
+- **Distributed tracing** — not needed at current scale
+- **Persistent queues** — thread-based queue is sufficient for current
+  throughput; replace with Redis/Celery if volume grows
+- **Circuit breakers** — added when external provider reliability
+  becomes a measurable concern
+
+These may be added to individual services as the application scales,
+not as a platform-wide requirement.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,174 @@
+# Observability Conventions
+
+This document defines the shared conventions for metrics, logging, and
+health reporting across all platform services.
+
+---
+
+## Metrics
+
+### Pattern
+
+Every service defines a dataclass with counter fields, a private
+`_durations: list[float]` for timing, an `avg_duration_ms` property,
+individual `record_*` methods, and a `snapshot() -> dict` method.
+
+```python
+@dataclass
+class ServiceNameMetrics:
+    operation_a: int = 0
+    operation_b: int = 0
+    failures: int = 0
+    _durations: list[float] = field(default_factory=list, repr=False)
+
+    @property
+    def avg_duration_ms(self) -> float:
+        if not self._durations:
+            return 0.0
+        return (sum(self._durations) / len(self._durations)) * 1000
+
+    def record_operation_a(self) -> None:
+        self.operation_a += 1
+
+    def record_duration(self, seconds: float) -> None:
+        self._durations.append(seconds)
+
+    def snapshot(self) -> dict:
+        return {
+            "operation_a": self.operation_a,
+            "operation_b": self.operation_b,
+            "failures": self.failures,
+            "avg_duration_ms": round(self.avg_duration_ms, 2),
+        }
+```
+
+### Conventions
+
+| Rule | Detail |
+|------|--------|
+| Class name | `<Service>Metrics` |
+| Counter names | Plural nouns describing the operation (`uploads`, `logins`) |
+| Failure counter | Named `failures` (not `failed`) |
+| Timing | `_durations` (private), `avg_duration_ms` (public property) |
+| Snapshot | `snapshot() -> dict` returns all counters + `avg_duration_ms` |
+| Rounding | `avg_duration_ms` rounded to 2 decimal places |
+
+### Current counters
+
+| Service | Counters |
+|---------|----------|
+| Mail | `queued`, `sent`, `failed`, `retried`, `avg_duration_ms` |
+| Auth | `registrations`, `logins`, `verifications`, `refreshes`, `failures`, `avg_duration_ms` |
+| Storage | `uploads`, `downloads`, `deletes`, `lists`, `failures`, `avg_duration_ms` |
+| Notifications | `sent`, `failed`, `bounced`, `avg_duration_ms` |
+
+---
+
+## Logging
+
+### Logger names
+
+```
+palmshed.{service}.audit
+```
+
+Examples: `palmshed.mail.audit`, `palmshed.auth.audit`
+
+### Event keys
+
+Every log call uses the service name as the event key:
+
+| Service | Event key |
+|---------|-----------|
+| Mail | `mail_event` |
+| Auth | `auth_event` |
+| Storage | `storage_event` |
+| Notifications | `notification_event` |
+
+### Logger class
+
+Each service defines a `<Service>Logger` class with two methods:
+
+- `log_result(result, **context)` — logs the outcome of an operation,
+  extracting all available metadata from the result object.
+- `log_send(..., **context)` or equivalent — logs a standalone operation
+  with explicit parameters when no result object is available.
+
+### Common log fields
+
+Every log entry should include these fields when available:
+
+| Field | Type | When |
+|-------|------|------|
+| `event` | `str` | Operation name (auth, storage) |
+| `service` | `str` | Service name (implied by event key) |
+| `status` | `str` | `success`, `failed`, etc. |
+| `provider` | `str` | Provider or channel name |
+| `duration_ms` | `float` | Operation duration |
+| `error` | `str` | Only when status is not success |
+
+Service-specific fields (e.g., `recipient`, `template`, `email`,
+`user_id`, `object_name`) are appended as appropriate.
+
+### Conventions
+
+- Use `logger.info(event_key, extra=entry)` — never `logger.warning`
+  or `logger.error` for audit events (status is encoded in the entry).
+- Conditionally include the `error` key — never set it to an empty string.
+- Timestamps are ISO 8601 strings.
+
+---
+
+## Health
+
+### Pattern
+
+Every service exposes a `health() -> HealthStatus` method that returns
+a dataclass with service status information.
+
+### Conventions
+
+| Rule | Detail |
+|------|--------|
+| Return type | Service-specific `HealthStatus` dataclass |
+| Config valid | Always include `config_valid: bool` + `config_errors: list[str]` |
+| Provider | Always include the active provider name |
+| Service-specific | Add fields per service (e.g., `queue_running`, `bucket`) |
+
+### Current health fields
+
+| Service | Health fields |
+|---------|---------------|
+| Mail | `provider`, `config_valid`, `config_errors`, `queue_running`, `queue_depth`, `templates_valid`, `template_count` |
+| Auth | `provider`, `config_valid`, `config_errors` |
+| Storage | `provider`, `config_valid`, `config_errors`, `bucket`, `healthy` |
+| Notifications | `enabled`, `channels` |
+
+---
+
+## Verify Alignment
+
+The `alma verify` CLI (`backend/verify.py`) reports health in a format
+that mirrors each service's health() output.
+
+- Platform checks call `service.health()` directly and map its fields
+  into the `details` dict.
+- JSON output keys match health status field names.
+- Application checks report independent of platform health but use the
+  same JSON structure (`name`, `status`, `latency`, `details`, `error`).
+
+When adding a new field to a service's `health()`, add the corresponding
+field to the verify CLI's check function for that service.
+
+---
+
+## Changelog
+
+When changing metrics, log fields, or health status fields:
+
+- Log field additions/removals: MINOR version bump (consumer-observable).
+- Metric counter additions: no version bump (stateless, no consumer impact).
+- Health status field additions: MINOR version bump (consumers may read them).
+- Health status field removals: MAJOR version bump.
+
+See [docs/versioning.md](versioning.md) for the full policy.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,97 @@
+# Project Philosophy
+
+This document captures the principles that guide how the repository
+is structured and maintained. It exists for future contributors who
+want to understand *why* things are the way they are.
+
+---
+
+## Principles
+
+### Prefer simple abstractions over generic frameworks
+
+Every abstraction should earn its keep. A `MailProvider` ABC exists
+because there are multiple mail backends with real switching
+requirements. A generic "ProviderFactory" meta-framework does not
+exist because it would add indirection without solving a concrete
+problem.
+
+Build for what you have, not for what you imagine you might one day
+need.
+
+### Build platform capabilities only after two products need them
+
+The platform services layer exists because future Palmshed products
+(Via, Nuntius, Glimpse) would each need mail, auth, storage, and
+notifications. Extracting those capabilities once for Alma avoids
+rebuilding them three more times.
+
+A capability that only one product will ever use does not belong in
+platform services. It belongs in the product.
+
+### Public APIs evolve conservatively
+
+Every symbol listed in a service's `__init__.py` `__all__` is a
+commitment. Changing it requires a major version bump, deprecation
+warnings, and a migration window.
+
+It is better to leave a symbol internal for an extra release than to
+expose it and immediately regret the shape.
+
+### Verification is required before every release
+
+`python -m backend.verify` must pass before any release is cut.
+This includes platform health checks plus application endpoint tests.
+If CI cannot verify the application in production, the release does
+not ship.
+
+### Documentation and tests are part of the implementation
+
+A feature is not complete until it has:
+
+- Tests that cover the public API
+- A service README that documents configuration and usage
+- Architecture boundary tests that prevent accidental coupling
+- A verify CLI entry that operators can run standalone
+
+Documentation is not a separate task. It is the same task.
+
+### Favor the standard library where practical
+
+Mail uses `http.client` instead of `requests`. Auth uses `hmac` +
+`hashlib` instead of `PyJWT`. Templates use `string.Template`
+instead of Jinja2.
+
+This is not a universal rule — when a dependency dramatically reduces
+code or complexity, use it. But default to stdlib first and justify
+every external dependency.
+
+### A healthy project says no
+
+The most important architectural skill is knowing when a capability
+is not yet needed. The platform will grow. It should grow because
+Alma needs it, not because there is another abstract service waiting
+to be extracted.
+
+---
+
+## What This Does Not Mean
+
+These principles do not prohibit good engineering. They are not an
+excuse to cut corners or defer necessary work. They exist to prevent
+the kind of over-engineering that produces elegant infrastructure
+and a mediocre product.
+
+The goal is a repository that is easy to understand, easy to change,
+and easy to operate — not one that is maximally abstract or
+theoretically pure.
+
+---
+
+## Related Documents
+
+- `AGENTS.md` — how to work in this repository
+- `docs/architecture.md` — what the platform looks like
+- `docs/architecture/*.md` — why specific decisions were made (ADRs)
+- `docs/versioning.md` — what counts as a breaking change
+- `docs/observability.md` — how services report their state

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,10 @@
+# Release Checklist
+
+- [ ] Version updated (`VERSION`, `__init__.py`, `pyproject.toml`)
+- [ ] CI passed
+- [ ] Smoke passed (`alma verify --platform --application`)
+- [ ] E2E passed (`alma verify ui --browser` against deployed app)
+- [ ] `alma verify` passed locally (platform + application + UI)
+- [ ] Production deployment healthy (`/api/health`)
+- [ ] Release artifacts archived (CI retains screenshots, HAR, console, report)
+- [ ] GitHub Release published with changelog

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,149 @@
+# Versioning Policy
+
+This document defines what constitutes a public API, how breaking
+changes are handled, and what versioning expectations consumers
+should have for platform services.
+
+---
+
+## Version Scheme
+
+Platform services follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+- **MAJOR** — incompatible API changes
+- **MINOR** — backward-compatible additions
+- **PATCH** — backward-compatible bug fixes
+
+All four services share the same version number (currently 0.1.0).
+Application code depends on `services` as a single unit, so there is
+no per-service version pinning.
+
+---
+
+## What Is Public API
+
+Every symbol listed in each service's `__init__.py` `__all__` is
+considered part of the public API.
+
+### Mail (`backend/services/mail/`)
+
+`MailConfig`, `MailMetrics`, `MailService`, `MailMessage`, `MailResult`,
+`MailStatus`, `MailPriority`, `MailError`, `MailValidationError`,
+`RetryPolicy`, `HealthStatus`, `ProviderCapabilities`, `MailTemplate`,
+`MailTemplates`, `TemplateDefinition`, `MailProvider`, `ProviderRegistry`,
+`MailQueue`, `get_provider`, `get_queue`
+
+### Auth (`backend/services/auth/`)
+
+`AuthConfig`, `AuthMetrics`, `AuthService`, `AuthResult`, `AuthStatus`,
+`TokenPair`, `User`, `AuthError`, `AuthValidationError`,
+`AuthHealthStatus`, `AuthProvider`, `ProviderRegistry`, `get_provider`
+
+### Storage (`backend/services/storage/`)
+
+`StorageConfig`, `StorageMetrics`, `StorageService`, `StorageObject`,
+`StorageResult`, `StorageStatus`, `StorageError`,
+`StorageValidationError`, `StorageHealth`, `ProviderCapabilities`,
+`StorageProvider`, `ProviderRegistry`, `get_provider`
+
+### Notifications (`backend/services/notifications/`)
+
+`NotificationConfig`, `NotificationMetrics`, `NotificationService`,
+`Notification`, `NotificationResult`, `NotificationStatus`,
+`NotificationPriority`, `NotificationError`, `NotificationHealth`,
+`ChannelCapabilities`, `NotificationChannel`, `MockChannel`,
+`EmailChannel`, `WebhookChannel`, `ChannelRegistry`, `get_channel`
+
+Everything else — internal modules, private functions, underscore-prefixed
+symbols, test helpers — is not part of the public API and may change
+without notice.
+
+---
+
+## What Counts as Breaking
+
+The following changes require a MAJOR version bump:
+
+- Removing or renaming a public symbol
+- Changing the signature of a public method
+- Changing the shape of a public dataclass or return type
+- Adding a required method to an abstract base class
+- Removing a registered enum member (e.g., `MailTemplate.WELCOME`)
+- Changing the meaning of an existing configuration field
+
+## What Does Not Count as Breaking
+
+The following are backward compatible (MINOR or PATCH):
+
+- Adding new public symbols
+- Adding optional parameters to public methods (with defaults)
+- Adding new enum members
+- Adding optional fields to config dataclasses
+- Adding new methods to ABCs with default implementations
+- Adding new providers via `ProviderRegistry`
+- Adding new templates or template definitions
+- Internal refactoring of modules not listed in `__all__`
+- Adding new environment variables
+- Changing metric names or log messages (consumer-observable but not API)
+
+---
+
+## Deprecation Process
+
+1. **Announce**: Mark the symbol as deprecated in its docstring.
+   Log a `DeprecationWarning` when the old path is used at runtime.
+
+2. **Support**: Keep the symbol for one MINOR version cycle after
+   deprecation. Consumers have at least one release to migrate.
+
+3. **Remove**: Delete the symbol in the next MAJOR version bump.
+   Include the removal in the changelog.
+
+Example:
+
+```python
+import warnings
+
+def old_function():
+    warnings.warn(
+        "old_function is deprecated, use new_function instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    # ... implementation ...
+```
+
+`DeprecationWarning` is silent by default in Python. Consumers who
+want to see them can use `-Wd` or filter explicitly:
+
+```bash
+python -Wd -c "from services.mail import old_function"
+```
+
+---
+
+## Changelog
+
+Each MAJOR and MINOR release must include a changelog entry describing:
+
+- New public symbols
+- Changed behavior
+- Deprecated symbols and their replacements
+- Removed symbols and migration path
+
+Changelog entries live in each service README under a "Changelog"
+section or in the repository-level `CHANGELOG.md`.
+
+---
+
+## Verify CLI Stability
+
+The `backend/verify.py` CLI follows its own stability contract:
+
+- `--json` output format is stable within a MAJOR version
+- Human-readable output may change without notice (it is for operators,
+  not parsers)
+- New flags and sub-commands are backward compatible
+- Removing a flag requires a MAJOR version bump
+- New keys in JSON output are backward compatible
+- Removing a key from JSON output requires a MAJOR version bump


### PR DESCRIPTION
## Summary

Final verification layer for the v0.1.0 platform baseline.

### Changes

- **Unified `alma verify` CLI**: `--platform`, `--application`, `ui` (`--static`, `--capabilities`, `--browser`)
- **`backend/verify_ui.py`**: capability detection, static frontend analysis (9 checks), Playwright browser verifier, evidence capture to `verify-output/`
- **SDK fix**: skip empty text parts in `generate_text_with_thinking()`
- **Logging fixes**: MailLogger now captures recipient/template, AuthLogger captures user_id
- **Documentation**: architecture, observability, philosophy, versioning, release checklist
- **CI workflows**: smoke (every push/PR), E2E (main push + daily + manual), release (verify + publish)
- **Tag**: `v0.1.0` pushed as reference release

### Verification

```
Platform:   PASS
Application: PASS (images quota expected)
UI static:  9/9 PASS
UI browser: all PASS (new conversation skip — viewport)
Production: all services healthy, zero console errors
```

Closes: v0.1.0 verification baseline