### PR TITLE
fix: use uv pip install playwright in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,9 @@ jobs:
           npm run build
 
       - name: Install Playwright
-        run: uv run pip install playwright && uv run python -m playwright install chromium
+        run: |
+          uv pip install playwright
+          uv run python -m playwright install chromium
 
       - name: Start backend
         run: |


### PR DESCRIPTION
pip install playwright installs outside uv venv; uv pip install playwright keeps it inside the managed environment.