### PR TITLE
fix: correct YAML indentation in E2E summarize step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,15 +108,7 @@ jobs:
         if: always()
         run: |
           if [ -f backend/verify-output/report.json ]; then
-            PASS=$(python3 -c "
-import json
-try:
-    r = json.load(open('backend/verify-output/report.json'))
-    s = r.get('summary', {})
-    print(s.get('ui_checks_passed', 'unknown'))
-except Exception as e:
-    print(f'error: {e}')
-" 2>/dev/null) || true
+            python3 -c "import json; r=json.load(open('backend/verify-output/report.json')); s=r.get('summary',{}); print('UI checks passed:', s.get('ui_checks_passed','unknown'))" 2>/dev/null || true
             echo "UI checks passed: $PASS"
           fi
           if [ -f /tmp/backend.log ]; then


### PR DESCRIPTION
The multi-line Python script inside the run: block had incorrect YAML indentation (content lines at column 1 instead of aligned with the block scalar). Switched to a one-liner Python command.