### PR TITLE
Use GitHub App for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,18 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'version-bump')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Get version
         id: version
@@ -122,6 +130,7 @@ jobs:
         if: steps.check.outputs.SKIP == 'false'
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: v${{ steps.version.outputs.VERSION }}
           name: v${{ steps.version.outputs.VERSION }}
           body_path: /tmp/release-notes.txt


### PR DESCRIPTION
Replace the default `GITHUB_TOKEN` with a token generated from a dedicated GitHub App so releases are attributed to the release app instead of the `github-actions` bot.

Secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` have been configured in the repo.