### PR TITLE
fix(ci): correct YAML indentation in bump-version.yml

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -77,9 +77,9 @@ jobs:
             --title "Prepare v${{ steps.version.outputs.NEW_VERSION }}" \
             --body "## Release
 
-        Prepare v${{ steps.version.outputs.NEW_VERSION }}.
+            Prepare v${{ steps.version.outputs.NEW_VERSION }}.
 
-        Please review the version bump before merging." \
+            Please review the version bump before merging." \
             --label version-bump
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Fixes YAML syntax error in `.github/workflows/bump-version.yml`.

The `--body` multi-line string for `gh pr create` was indented at 8 spaces, causing it to escape the 10-space flow scalar and fail parsing at the first continuation line.

Both workflow files now validate successfully.