### PR TITLE
fix(ci): use correct pull-requests permission key

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -24,7 +24,7 @@ on:
 
 permissions:
   contents: write
-  pull_requests: write
+  pull-requests: write
 
 jobs:
   bump:


### PR DESCRIPTION
Fix for GitHub Actions validation error:

`Invalid workflow file (Line: 27, Col: 3): Unexpected value 'pull_requests'`

Changed `pull_requests: write` to `pull-requests: write` in the `permissions` block of `.github/workflows/bump-version.yml`.