### PR TITLE
fix(ci): hardcode git author name and email in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -42,10 +42,10 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Configure Git author
-        run: |
-          git config user.name "palmshed-alma[bot]"
-          git config user.email "${{ secrets.RELEASE_APP_ID }}+palmshed-alma[bot]@users.noreply.github.com"
+- name: Configure Git author
+  run: |
+    git config user.name "palmshed-alma[bot]"
+    git config user.email "4219484+palmshed-alma[bot]@users.noreply.github.com"
 
       - name: Bump version
         id: version


### PR DESCRIPTION
Hardcodes the git author name and email in the bump-version workflow so version-bump PRs are consistently attributed to `palmshed-alma[bot]` regardless of secret availability.