### PR TITLE
fix(ci): restore proper step structure for Configure Git author in bump-version.yml

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -42,10 +42,10 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-- name: Configure Git author
-  run: |
-    git config user.name "palmshed-alma[bot]"
-    git config user.email "4219484+palmshed-alma[bot]@users.noreply.github.com"
+      - name: Configure Git author
+        run: |
+          git config user.name "palmshed-alma[bot]"
+          git config user.email "4219484+palmshed-alma[bot]@users.noreply.github.com"
 
       - name: Bump version
         id: version


### PR DESCRIPTION
Restores the missing list-item prefix for the 'Configure Git author' step in .github/workflows/bump-version.yml, fixing the YAML syntax error.