### PR TITLE
fix(ci): use correct GitHub user ID for git author email

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure Git author
         run: |
           git config user.name "palmshed-alma[bot]"
-          git config user.email "4219484+palmshed-alma[bot]@users.noreply.github.com"
+          git config user.email "300001495+palmshed-alma[bot]@users.noreply.github.com"
 
       - name: Bump version
         id: version


### PR DESCRIPTION
## Fix

The git author email in the bump-version workflow used the app installation ID (`4219484`) instead of the actual GitHub App user ID (`300001495`).

### Change

```diff
- git config user.email "4219484+palmshed-alma[bot]@users.noreply.github.com"
+ git config user.email "300001495+palmshed-alma[bot]@users.noreply.github.com"
```

The amended commit on `automated/version-bump` (PR #72) has also been force-pushed with the corrected email.

### How to find the correct user ID

Do not rely on the noreply commit email — that uses the **app installation ID**, not the account ID.

Instead, query the GitHub API for the user/bot:

```
curl -s https://api.github.com/repos/palmshed/alma/pulls/72 | jq .user
```

Or for any user:

```
curl -s https://api.github.com/users/USERNAME | jq .id
```

The `id` field in the response is the real GitHub user ID.