### PR TITLE
v0.3.0 — Attachment lifecycle (Phase 5-6)

### DIFF
--- a/backend/palmshed_ai/__init__.py
+++ b/backend/palmshed_ai/__init__.py
@@ -57,9 +57,11 @@ def create_app():
 
     # Register blueprints
     from .routes.api import api_bp
+    from .routes.attachments import attachments_bp
     from .routes.conversations import conversations_bp
 
     app.register_blueprint(api_bp)
+    app.register_blueprint(attachments_bp)
     app.register_blueprint(conversations_bp)
 
     # Apply rate limiting to API routes

--- a/backend/palmshed_ai/conversations/__init__.py
+++ b/backend/palmshed_ai/conversations/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
 # SPDX-License-Identifier: MIT
 
+from .attachment_store import AttachmentStore
 from .attachments import Attachment, ATTACHMENT_SCHEMA_VERSION
 from .models import Conversation, Message, SCHEMA_VERSION
 from .store import ConversationStore, IndexEntry
@@ -8,6 +9,7 @@ from .store import ConversationStore, IndexEntry
 __all__ = [
     "Attachment",
     "ATTACHMENT_SCHEMA_VERSION",
+    "AttachmentStore",
     "Conversation",
     "Message",
     "SCHEMA_VERSION",

--- a/backend/palmshed_ai/conversations/__init__.py
+++ b/backend/palmshed_ai/conversations/__init__.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
 # SPDX-License-Identifier: MIT
 
+from .attachments import Attachment, ATTACHMENT_SCHEMA_VERSION
 from .models import Conversation, Message, SCHEMA_VERSION
 from .store import ConversationStore, IndexEntry
 
 __all__ = [
+    "Attachment",
+    "ATTACHMENT_SCHEMA_VERSION",
     "Conversation",
     "Message",
     "SCHEMA_VERSION",

--- a/backend/palmshed_ai/conversations/attachment_store.py
+++ b/backend/palmshed_ai/conversations/attachment_store.py
@@ -37,9 +37,7 @@ class AttachmentStore:
     def load_data(self, attachment_id: str) -> Optional[bytes]:
         return self._load_data(attachment_id)
 
-    def load_with_data(
-        self, attachment_id: str
-    ) -> Optional[tuple[Attachment, bytes]]:
+    def load_with_data(self, attachment_id: str) -> Optional[tuple[Attachment, bytes]]:
         attachment = self.load_metadata(attachment_id)
         if attachment is None:
             return None
@@ -64,6 +62,25 @@ class AttachmentStore:
         except StorageError:
             pass
         return sorted(ids)
+
+    def update_metadata(self, attachment_id: str, updates: dict[str, object]) -> bool:
+        """Update specific keys in the attachment's metadata dict.
+
+        The metadata dict is the application-defined metadata bag on the
+        Attachment object, not the top-level fields. This is used to store
+        non-ownership references such as conversation_id and message_id.
+
+        Returns True if the metadata was updated, False if the attachment
+        does not exist.
+        """
+        attachment = self._load_metadata(attachment_id)
+        if attachment is None:
+            return False
+        if attachment.metadata is None:
+            attachment.metadata = {}
+        attachment.metadata.update(updates)
+        self._save_metadata(attachment)
+        return True
 
     def metadata_exists(self, attachment_id: str) -> bool:
         return self._storage.exists(self._metadata_path(attachment_id))

--- a/backend/palmshed_ai/conversations/attachment_store.py
+++ b/backend/palmshed_ai/conversations/attachment_store.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from services.storage import StorageService, StorageError
+
+from .attachments import Attachment
+
+logger = logging.getLogger(__name__)
+
+ATTACHMENTS_PREFIX = "attachments/"
+METADATA_PREFIX = "attachment-metadata/"
+
+
+class AttachmentStoreError(Exception):
+    pass
+
+
+class AttachmentStore:
+    def __init__(self, storage: StorageService) -> None:
+        self._storage = storage
+
+    # ── public API ──
+
+    def save(self, attachment: Attachment, data: bytes) -> None:
+        self._save_binary(attachment, data)
+        self._save_metadata(attachment)
+
+    def load_metadata(self, attachment_id: str) -> Optional[Attachment]:
+        return self._load_metadata(attachment_id)
+
+    def load_data(self, attachment_id: str) -> Optional[bytes]:
+        return self._load_data(attachment_id)
+
+    def load_with_data(
+        self, attachment_id: str
+    ) -> Optional[tuple[Attachment, bytes]]:
+        attachment = self.load_metadata(attachment_id)
+        if attachment is None:
+            return None
+        data = self._load_data(attachment_id)
+        if data is None:
+            return None
+        return attachment, data
+
+    def delete(self, attachment_id: str) -> bool:
+        deleted_meta = self._delete_metadata(attachment_id)
+        deleted_bin = self._delete_binary(attachment_id)
+        return deleted_meta or deleted_bin
+
+    def list_ids(self) -> list[str]:
+        ids: set[str] = set()
+        try:
+            names = self._storage.list(METADATA_PREFIX)
+            for name in names:
+                if name.endswith(".json"):
+                    att_id = name.removeprefix(METADATA_PREFIX).removesuffix(".json")
+                    ids.add(att_id)
+        except StorageError:
+            pass
+        return sorted(ids)
+
+    def metadata_exists(self, attachment_id: str) -> bool:
+        return self._storage.exists(self._metadata_path(attachment_id))
+
+    def binary_exists(self, attachment_id: str) -> bool:
+        return self._storage.exists(self._binary_path(attachment_id))
+
+    # ── path helpers ──
+
+    @staticmethod
+    def _binary_path(attachment_id: str) -> str:
+        return f"{ATTACHMENTS_PREFIX}{attachment_id}.bin"
+
+    @staticmethod
+    def _metadata_path(attachment_id: str) -> str:
+        return f"{METADATA_PREFIX}{attachment_id}.json"
+
+    # ── binary storage ──
+
+    def _save_binary(self, attachment: Attachment, data: bytes) -> None:
+        path = self._binary_path(attachment.id)
+        self._storage.upload(
+            path,
+            data,
+            content_type=attachment.mime_type,
+        )
+
+    def _load_data(self, attachment_id: str) -> Optional[bytes]:
+        path = self._binary_path(attachment_id)
+        try:
+            _, data = self._storage.download(path)
+            return data
+        except StorageError:
+            return None
+
+    def _delete_binary(self, attachment_id: str) -> bool:
+        path = self._binary_path(attachment_id)
+        try:
+            self._storage.delete(path)
+            return True
+        except StorageError:
+            return False
+
+    # ── metadata storage ──
+
+    def _save_metadata(self, attachment: Attachment) -> None:
+        path = self._metadata_path(attachment.id)
+        self._storage.upload(
+            path,
+            json.dumps(attachment.to_dict(), indent=2).encode("utf-8"),
+            content_type="application/json",
+        )
+
+    def _load_metadata(self, attachment_id: str) -> Optional[Attachment]:
+        path = self._metadata_path(attachment_id)
+        try:
+            _, raw = self._storage.download(path)
+            raw_dict = json.loads(raw.decode("utf-8"))
+            return Attachment.from_dict(raw_dict)
+        except (StorageError, json.JSONDecodeError, KeyError, ValueError) as exc:
+            logger.warning(
+                "Failed to load attachment metadata %s: %s", attachment_id, exc
+            )
+            return None
+
+    def _delete_metadata(self, attachment_id: str) -> bool:
+        path = self._metadata_path(attachment_id)
+        try:
+            self._storage.delete(path)
+            return True
+        except StorageError:
+            return False

--- a/backend/palmshed_ai/conversations/attachments.py
+++ b/backend/palmshed_ai/conversations/attachments.py
@@ -59,9 +59,7 @@ class Attachment:
                 f"supported version {ATTACHMENT_SCHEMA_VERSION}. Upgrade required."
             )
         extra = {
-            k: copy.deepcopy(v)
-            for k, v in d.items()
-            if k not in _KNOWN_ATTACHMENT_KEYS
+            k: copy.deepcopy(v) for k, v in d.items() if k not in _KNOWN_ATTACHMENT_KEYS
         }
         return cls(
             id=d["id"],

--- a/backend/palmshed_ai/conversations/attachments.py
+++ b/backend/palmshed_ai/conversations/attachments.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any
+
+ATTACHMENT_SCHEMA_VERSION = 1
+
+_KNOWN_ATTACHMENT_KEYS = {
+    "id",
+    "filename",
+    "mime_type",
+    "size",
+    "checksum",
+    "storage_key",
+    "created_at",
+    "metadata",
+    "schema_version",
+}
+
+
+@dataclass
+class Attachment:
+    id: str
+    filename: str
+    mime_type: str
+    size: int
+    checksum: str
+    storage_key: str
+    created_at: str
+    metadata: dict[str, Any] | None = None
+    schema_version: int = ATTACHMENT_SCHEMA_VERSION
+    _extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        d["id"] = self.id
+        d["filename"] = self.filename
+        d["mime_type"] = self.mime_type
+        d["size"] = self.size
+        d["checksum"] = self.checksum
+        d["storage_key"] = self.storage_key
+        d["created_at"] = self.created_at
+        d["schema_version"] = self.schema_version
+        if self.metadata:
+            d["metadata"] = copy.deepcopy(self.metadata)
+        d.update(self._extra)
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Attachment:
+        schema_version = d.get("schema_version", 0)
+        if schema_version > ATTACHMENT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Attachment schema version {schema_version} is newer than "
+                f"supported version {ATTACHMENT_SCHEMA_VERSION}. Upgrade required."
+            )
+        extra = {
+            k: copy.deepcopy(v)
+            for k, v in d.items()
+            if k not in _KNOWN_ATTACHMENT_KEYS
+        }
+        return cls(
+            id=d["id"],
+            filename=d["filename"],
+            mime_type=d["mime_type"],
+            size=d["size"],
+            checksum=d["checksum"],
+            storage_key=d["storage_key"],
+            created_at=d["created_at"],
+            metadata=copy.deepcopy(d.get("metadata")),
+            schema_version=schema_version,
+            _extra=extra,
+        )

--- a/backend/palmshed_ai/routes/attachments.py
+++ b/backend/palmshed_ai/routes/attachments.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import uuid
+from datetime import datetime, timezone
+
+from flask import Blueprint, request, jsonify, send_file
+from services import platform
+
+from palmshed_ai.conversations import Attachment, AttachmentStore
+
+import io
+
+attachments_bp = Blueprint("attachments", __name__)
+
+SUPPORTED_MIME_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+    "application/pdf",
+    "text/plain",
+    "text/markdown",
+}
+
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _get_store() -> AttachmentStore:
+    return AttachmentStore(storage=platform.storage)
+
+
+@attachments_bp.route("/api/attachments", methods=["POST"])
+def upload_attachment():
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files["file"]
+    if file.filename == "" or not file.filename:
+        return jsonify({"error": "No file selected"}), 400
+
+    data = file.read()
+    if len(data) == 0:
+        return jsonify({"error": "Empty file"}), 400
+
+    if len(data) > MAX_UPLOAD_SIZE:
+        return jsonify({
+            "error": f"File too large ({len(data)} bytes); max is {MAX_UPLOAD_SIZE}"
+        }), 413
+
+    mime_type = file.content_type or "application/octet-stream"
+    if mime_type not in SUPPORTED_MIME_TYPES:
+        return jsonify({
+            "error": f"Unsupported file type: {mime_type}"
+        }), 415
+
+    checksum = hashlib.sha256(data).hexdigest()
+    attachment_id = str(uuid.uuid4())
+    storage_key = f"attachments/{attachment_id}.bin"
+
+    attachment = Attachment(
+        id=attachment_id,
+        filename=file.filename,
+        mime_type=mime_type,
+        size=len(data),
+        checksum=checksum,
+        storage_key=storage_key,
+        created_at=_now_utc(),
+    )
+
+    store = _get_store()
+    store.save(attachment, data)
+
+    return jsonify(attachment.to_dict()), 201
+
+
+@attachments_bp.route("/api/attachments/<attachment_id>", methods=["GET"])
+def download_attachment(attachment_id):
+    store = _get_store()
+    result = store.load_with_data(attachment_id)
+    if result is None:
+        return jsonify({"error": "Attachment not found"}), 404
+
+    attachment, data = result
+    return send_file(
+        io.BytesIO(data),
+        mimetype=attachment.mime_type,
+        as_attachment=False,
+        download_name=attachment.filename,
+    )
+
+
+@attachments_bp.route(
+    "/api/attachments/<attachment_id>/metadata", methods=["GET"]
+)
+def get_attachment_metadata(attachment_id):
+    store = _get_store()
+    attachment = store.load_metadata(attachment_id)
+    if attachment is None:
+        return jsonify({"error": "Attachment not found"}), 404
+
+    return jsonify(attachment.to_dict())
+
+
+@attachments_bp.route("/api/attachments/<attachment_id>", methods=["DELETE"])
+def delete_attachment(attachment_id):
+    store = _get_store()
+    success = store.delete(attachment_id)
+    if not success:
+        return jsonify({"error": "Attachment not found"}), 404
+    return "", 204

--- a/backend/palmshed_ai/routes/attachments.py
+++ b/backend/palmshed_ai/routes/attachments.py
@@ -49,15 +49,13 @@ def upload_attachment():
         return jsonify({"error": "Empty file"}), 400
 
     if len(data) > MAX_UPLOAD_SIZE:
-        return jsonify({
-            "error": f"File too large ({len(data)} bytes); max is {MAX_UPLOAD_SIZE}"
-        }), 413
+        return jsonify(
+            {"error": f"File too large ({len(data)} bytes); max is {MAX_UPLOAD_SIZE}"}
+        ), 413
 
     mime_type = file.content_type or "application/octet-stream"
     if mime_type not in SUPPORTED_MIME_TYPES:
-        return jsonify({
-            "error": f"Unsupported file type: {mime_type}"
-        }), 415
+        return jsonify({"error": f"Unsupported file type: {mime_type}"}), 415
 
     checksum = hashlib.sha256(data).hexdigest()
     attachment_id = str(uuid.uuid4())
@@ -95,9 +93,7 @@ def download_attachment(attachment_id):
     )
 
 
-@attachments_bp.route(
-    "/api/attachments/<attachment_id>/metadata", methods=["GET"]
-)
+@attachments_bp.route("/api/attachments/<attachment_id>/metadata", methods=["GET"])
 def get_attachment_metadata(attachment_id):
     store = _get_store()
     attachment = store.load_metadata(attachment_id)

--- a/backend/palmshed_ai/routes/conversations.py
+++ b/backend/palmshed_ai/routes/conversations.py
@@ -1,12 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
 # SPDX-License-Identifier: MIT
 
+import logging
 import uuid
 from datetime import datetime, timezone
 
 from flask import Blueprint, g, request, jsonify
 from services import platform
-from palmshed_ai.conversations import ConversationStore, Conversation
+from palmshed_ai.conversations import (
+    AttachmentStore,
+    ConversationStore,
+    Conversation,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def _now_utc() -> str:
@@ -20,10 +27,78 @@ def _get_store() -> ConversationStore:
     return ConversationStore(storage=platform.storage, owner_id=g.client_id)
 
 
+def _get_attachment_store() -> AttachmentStore:
+    return AttachmentStore(storage=platform.storage)
+
+
 def _ensure_message_ids(messages: list[dict]) -> None:
     for msg in messages:
         if not msg.get("id"):
             msg["id"] = str(uuid.uuid4())
+
+
+def _populate_attachment_references(conversation_id: str, messages: list) -> None:
+    """Store conversation_id and message_id on each referenced attachment.
+
+    These are references only, not ownership — the attachment remains
+    independently addressable and reusable.
+    """
+    att_store = _get_attachment_store()
+    for msg in messages:
+        attachments = (
+            msg.attachments if hasattr(msg, "attachments") else msg.get("attachments")
+        )
+        if not attachments:
+            continue
+        message_id = msg.id if hasattr(msg, "id") else msg["id"]
+        for ref in attachments:
+            att_id = ref.get("id") if isinstance(ref, dict) else ref.id
+            if att_id:
+                att_store.update_metadata(
+                    att_id,
+                    {"conversation_id": conversation_id, "message_id": message_id},
+                )
+
+
+def _cleanup_attachments_for_conversation(
+    conversation_id: str,
+) -> list[str]:
+    """Delete all attachments referenced by messages in a conversation.
+
+    Returns a list of attachment IDs that could not be deleted.
+    Does not raise — failures are logged and collected.
+    """
+    store = _get_store()
+    conv = store.load(conversation_id)
+    if conv is None:
+        return []
+
+    att_store = _get_attachment_store()
+    failures: list[str] = []
+    seen: set[str] = set()
+    for msg in conv.messages:
+        if not msg.attachments:
+            continue
+        for ref in msg.attachments:
+            att_id = ref.get("id") if isinstance(ref, dict) else ref.id
+            if att_id in seen:
+                continue
+            seen.add(att_id)
+            try:
+                if not att_store.delete(att_id):
+                    logger.warning(
+                        "Attachment %s not found during conversation %s cleanup",
+                        att_id,
+                        conversation_id,
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to delete attachment %s during conversation %s cleanup",
+                    att_id,
+                    conversation_id,
+                )
+                failures.append(att_id)
+    return failures
 
 
 @conversations_bp.route("/api/conversations", methods=["GET"])
@@ -71,6 +146,9 @@ def create_conversation():
         conv.title = _default_title(conv)
 
     created = store.create(conv)
+
+    _populate_attachment_references(created.id, created.messages)
+
     return jsonify(created.to_dict()), 201
 
 
@@ -100,15 +178,29 @@ def update_conversation(conversation_id):
         return jsonify({"error": f"Invalid conversation data: {e}"}), 400
 
     store.save(conv)
+
+    _populate_attachment_references(conv.id, conv.messages)
+
     return jsonify(conv.to_dict())
 
 
 @conversations_bp.route("/api/conversations/<conversation_id>", methods=["DELETE"])
 def delete_conversation(conversation_id):
+    failures = _cleanup_attachments_for_conversation(conversation_id)
+
     store = _get_store()
     success = store.delete(conversation_id)
     if not success:
         return jsonify({"error": "Conversation not found"}), 404
+
+    if failures:
+        logger.warning(
+            "Conversation %s deleted but %d attachments could not be removed: %s",
+            conversation_id,
+            len(failures),
+            ", ".join(failures),
+        )
+
     return "", 204
 
 

--- a/backend/tests/test_attachment_api.py
+++ b/backend/tests/test_attachment_api.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import io
+import json
 import os
 import uuid
 
@@ -56,9 +57,7 @@ class TestAttachmentUpload:
         assert body["mime_type"] == "image/jpeg"
 
     def test_upload_pdf(self, client):
-        data = {
-            "file": (io.BytesIO(b"%PDF-1.4 fake"), "doc.pdf", "application/pdf")
-        }
+        data = {"file": (io.BytesIO(b"%PDF-1.4 fake"), "doc.pdf", "application/pdf")}
         resp = client.post(
             "/api/attachments",
             data=data,
@@ -69,9 +68,7 @@ class TestAttachmentUpload:
         assert body["mime_type"] == "application/pdf"
 
     def test_upload_text(self, client):
-        data = {
-            "file": (io.BytesIO(b"hello world"), "notes.txt", "text/plain")
-        }
+        data = {"file": (io.BytesIO(b"hello world"), "notes.txt", "text/plain")}
         resp = client.post(
             "/api/attachments",
             data=data,
@@ -109,6 +106,7 @@ class TestAttachmentUpload:
         assert resp.status_code == 201
         body = resp.get_json()
         import hashlib
+
         expected = hashlib.sha256(content).hexdigest()
         assert body["checksum"] == expected
 
@@ -302,3 +300,217 @@ class TestAttachmentWorkflow:
         assert client.get(f"/api/attachments/{ids[0]}").status_code == 200
         assert client.get(f"/api/attachments/{ids[1]}").status_code == 404
         assert client.get(f"/api/attachments/{ids[2]}").status_code == 200
+
+
+TIMESTAMP = "2026-07-07T12:00:00Z"
+
+
+class TestAttachmentConversationLifecycle:
+    """Phase 5 + Phase 6: populate references + cleanup on conversation delete."""
+
+    def _upload(self, client, content: bytes, filename: str, mime: str) -> str:
+        data = {"file": (io.BytesIO(content), filename, mime)}
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        return resp.get_json()["id"]
+
+    def _create_conv(self, client, messages: list[dict]) -> dict:
+        for msg in messages:
+            msg.setdefault("timestamp", TIMESTAMP)
+        resp = client.post(
+            "/api/conversations",
+            data=json.dumps(
+                {
+                    "mode": "chat",
+                    "title": "Attachment lifecycle test",
+                    "messages": messages,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 201, f"Create failed: {resp.get_json()}"
+        return resp.get_json()
+
+    def _get_conv(self, client, conv_id: str) -> dict:
+        resp = client.get(f"/api/conversations/{conv_id}")
+        assert resp.status_code == 200
+        return resp.get_json()
+
+    def test_create_conversation_populates_attachment_refs(self, client):
+        img_id = self._upload(client, PNG_HEADER + b"img", "photo.png", "image/png")
+        pdf_id = self._upload(client, b"%PDF-data", "doc.pdf", "application/pdf")
+
+        conv = self._create_conv(
+            client,
+            [
+                {
+                    "role": "user",
+                    "content": "Check these files",
+                    "attachments": [
+                        {
+                            "id": img_id,
+                            "filename": "photo.png",
+                            "mime_type": "image/png",
+                            "size": 7,
+                        },
+                        {
+                            "id": pdf_id,
+                            "filename": "doc.pdf",
+                            "mime_type": "application/pdf",
+                            "size": 9,
+                        },
+                    ],
+                },
+            ],
+        )
+        conv_id = conv["id"]
+        msg_id = conv["messages"][0]["id"]
+
+        # Verify metadata was populated
+        meta_resp = client.get(f"/api/attachments/{img_id}/metadata")
+        assert meta_resp.status_code == 200
+        meta = meta_resp.get_json()
+        assert meta.get("metadata", {}).get("conversation_id") == conv_id
+        assert meta.get("metadata", {}).get("message_id") == msg_id
+
+        meta_resp2 = client.get(f"/api/attachments/{pdf_id}/metadata")
+        assert meta_resp2.status_code == 200
+        meta2 = meta_resp2.get_json()
+        assert meta2.get("metadata", {}).get("conversation_id") == conv_id
+        assert meta2.get("metadata", {}).get("message_id") == msg_id
+
+    def test_delete_conversation_removes_attachments(self, client):
+        img_id = self._upload(client, PNG_HEADER + b"del", "del.png", "image/png")
+        pdf_id = self._upload(client, b"%DEL-data", "del.pdf", "application/pdf")
+
+        conv = self._create_conv(
+            client,
+            [
+                {
+                    "role": "user",
+                    "content": "Delete test",
+                    "attachments": [
+                        {
+                            "id": img_id,
+                            "filename": "del.png",
+                            "mime_type": "image/png",
+                            "size": 7,
+                        },
+                        {
+                            "id": pdf_id,
+                            "filename": "del.pdf",
+                            "mime_type": "application/pdf",
+                            "size": 9,
+                        },
+                    ],
+                },
+            ],
+        )
+        conv_id = conv["id"]
+
+        # Verify attachments exist before delete
+        assert client.get(f"/api/attachments/{img_id}").status_code == 200
+        assert client.get(f"/api/attachments/{pdf_id}").status_code == 200
+
+        # Delete the conversation
+        del_resp = client.delete(f"/api/conversations/{conv_id}")
+        assert del_resp.status_code == 204
+
+        # Verify attachments were also removed
+        assert client.get(f"/api/attachments/{img_id}").status_code == 404
+        assert client.get(f"/api/attachments/{pdf_id}").status_code == 404
+
+    def test_delete_conversation_without_attachments_succeeds(self, client):
+        conv = self._create_conv(
+            client,
+            [
+                {"role": "user", "content": "No attachments"},
+            ],
+        )
+        del_resp = client.delete(f"/api/conversations/{conv['id']}")
+        assert del_resp.status_code == 204
+
+    def test_delete_conversation_twice_idempotent(self, client):
+        conv = self._create_conv(
+            client,
+            [
+                {"role": "user", "content": "Idempotent test"},
+            ],
+        )
+        conv_id = conv["id"]
+        assert client.delete(f"/api/conversations/{conv_id}").status_code == 204
+        assert client.delete(f"/api/conversations/{conv_id}").status_code == 404
+
+    def test_attachment_not_referenced_by_deleted_message(self, client):
+        """Attachments in a deleted conversation should not be loadable after cleanup."""
+        att_id = self._upload(client, b"orphan-check", "orphan.txt", "text/plain")
+        conv = self._create_conv(
+            client,
+            [
+                {
+                    "role": "user",
+                    "content": "Orphan test",
+                    "attachments": [
+                        {
+                            "id": att_id,
+                            "filename": "orphan.txt",
+                            "mime_type": "text/plain",
+                            "size": 11,
+                        },
+                    ],
+                },
+            ],
+        )
+        conv_id = conv["id"]
+
+        # Verify attachment metadata has references
+        meta_resp = client.get(f"/api/attachments/{att_id}/metadata")
+        meta = meta_resp.get_json()
+        assert meta.get("metadata", {}).get("conversation_id") == conv_id
+
+        # Delete conversation
+        assert client.delete(f"/api/conversations/{conv_id}").status_code == 204
+
+        # Attachment should be gone
+        assert client.get(f"/api/attachments/{att_id}").status_code == 404
+        assert client.get(f"/api/attachments/{att_id}/metadata").status_code == 404
+
+    def test_conversation_with_same_attachment_multiple_messages(self, client):
+        """Deduplication: same attachment in multiple messages — only deleted once."""
+        att_id = self._upload(client, b"shared-att", "shared.txt", "text/plain")
+        conv = self._create_conv(
+            client,
+            [
+                {
+                    "role": "user",
+                    "content": "First message",
+                    "attachments": [
+                        {
+                            "id": att_id,
+                            "filename": "shared.txt",
+                            "mime_type": "text/plain",
+                            "size": 10,
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": "Second message",
+                    "attachments": [
+                        {
+                            "id": att_id,
+                            "filename": "shared.txt",
+                            "mime_type": "text/plain",
+                            "size": 10,
+                        },
+                    ],
+                },
+            ],
+        )
+
+        assert client.delete(f"/api/conversations/{conv['id']}").status_code == 204
+        assert client.get(f"/api/attachments/{att_id}").status_code == 404

--- a/backend/tests/test_attachment_api.py
+++ b/backend/tests/test_attachment_api.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+
+import io
+import os
+import uuid
+
+import pytest
+
+from palmshed_ai import create_app
+
+os.environ["GEMINI_API_KEY"] = "dummy"
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+PNG_HEADER = b"\x89PNG\r\n\x1a\n"
+
+
+class TestAttachmentUpload:
+    def test_upload_png(self, client):
+        data = {"file": (io.BytesIO(PNG_HEADER + b"fake-data"), "photo.png")}
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["filename"] == "photo.png"
+        assert body["mime_type"] == "image/png"
+        assert body["size"] == len(PNG_HEADER + b"fake-data")
+        assert "id" in body
+        assert "checksum" in body
+        assert uuid.UUID(body["id"])
+
+    def test_upload_jpeg(self, client):
+        data = {"file": (io.BytesIO(b"fake-jpeg"), "photo.jpg", "image/jpeg")}
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["mime_type"] == "image/jpeg"
+
+    def test_upload_pdf(self, client):
+        data = {
+            "file": (io.BytesIO(b"%PDF-1.4 fake"), "doc.pdf", "application/pdf")
+        }
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["mime_type"] == "application/pdf"
+
+    def test_upload_text(self, client):
+        data = {
+            "file": (io.BytesIO(b"hello world"), "notes.txt", "text/plain")
+        }
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["mime_type"] == "text/plain"
+
+    def test_upload_markdown(self, client):
+        data = {
+            "file": (
+                io.BytesIO(b"# Hello"),
+                "readme.md",
+                "text/markdown",
+            )
+        }
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["mime_type"] == "text/markdown"
+
+    def test_upload_checksum_sha256(self, client):
+        content = b"hello-world-checksum"
+        data = {"file": (io.BytesIO(content), "test.txt", "text/plain")}
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        import hashlib
+        expected = hashlib.sha256(content).hexdigest()
+        assert body["checksum"] == expected
+
+
+class TestAttachmentUploadErrors:
+    def test_no_file(self, client):
+        resp = client.post(
+            "/api/attachments",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "No file" in resp.get_json()["error"]
+
+    def test_empty_filename(self, client):
+        data = {"file": (io.BytesIO(b"data"), "", "text/plain")}
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "No file" in resp.get_json()["error"]
+
+    def test_empty_file(self, client):
+        data = {"file": (io.BytesIO(b""), "empty.txt", "text/plain")}
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "Empty" in resp.get_json()["error"]
+
+    def test_unsupported_mime_type(self, client):
+        data = {
+            "file": (
+                io.BytesIO(b"<html></html>"),
+                "page.html",
+                "text/html",
+            )
+        }
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 415
+        assert "Unsupported" in resp.get_json()["error"]
+
+    def test_file_too_large(self, client):
+        large_data = b"x" * (10 * 1024 * 1024 + 1)
+        data = {"file": (io.BytesIO(large_data), "large.bin", "text/plain")}
+        resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 413
+        assert "too large" in resp.get_json()["error"]
+
+
+class TestAttachmentDownload:
+    def test_download_returns_file(self, client):
+        content = b"downloadable-content"
+        data = {"file": (io.BytesIO(content), "download.txt", "text/plain")}
+        upload_resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        att_id = upload_resp.get_json()["id"]
+
+        download_resp = client.get(f"/api/attachments/{att_id}")
+        assert download_resp.status_code == 200
+        assert download_resp.data == content
+        assert download_resp.content_type.startswith("text/plain")
+
+    def test_download_nonexistent(self, client):
+        resp = client.get("/api/attachments/nonexistent-id")
+        assert resp.status_code == 404
+
+
+class TestAttachmentMetadata:
+    def test_get_metadata(self, client):
+        content = b"metadata-test"
+        data = {"file": (io.BytesIO(content), "meta.txt", "text/plain")}
+        upload_resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        body = upload_resp.get_json()
+        att_id = body["id"]
+
+        meta_resp = client.get(f"/api/attachments/{att_id}/metadata")
+        assert meta_resp.status_code == 200
+        meta = meta_resp.get_json()
+        assert meta["id"] == att_id
+        assert meta["filename"] == "meta.txt"
+        assert meta["mime_type"] == "text/plain"
+        assert meta["size"] == len(content)
+        assert "checksum" in meta
+        assert "created_at" in meta
+
+    def test_get_metadata_nonexistent(self, client):
+        resp = client.get("/api/attachments/nonexistent/metadata")
+        assert resp.status_code == 404
+
+
+class TestAttachmentDelete:
+    def test_delete_attachment(self, client):
+        data = {"file": (io.BytesIO(b"to-delete"), "delete.txt", "text/plain")}
+        upload_resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        att_id = upload_resp.get_json()["id"]
+
+        del_resp = client.delete(f"/api/attachments/{att_id}")
+        assert del_resp.status_code == 204
+
+        get_resp = client.get(f"/api/attachments/{att_id}")
+        assert get_resp.status_code == 404
+
+    def test_delete_nonexistent(self, client):
+        resp = client.delete("/api/attachments/nonexistent")
+        assert resp.status_code == 404
+
+    def test_delete_twice(self, client):
+        data = {"file": (io.BytesIO(b"twice"), "twice.txt", "text/plain")}
+        upload_resp = client.post(
+            "/api/attachments",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        att_id = upload_resp.get_json()["id"]
+
+        client.delete(f"/api/attachments/{att_id}")
+        resp = client.delete(f"/api/attachments/{att_id}")
+        assert resp.status_code == 404
+
+
+class TestAttachmentWorkflow:
+    def test_upload_download_delete_cycle(self, client):
+        content = b"full-cycle-test"
+        upload_resp = client.post(
+            "/api/attachments",
+            data={"file": (io.BytesIO(content), "cycle.txt", "text/plain")},
+            content_type="multipart/form-data",
+        )
+        assert upload_resp.status_code == 201
+        att_id = upload_resp.get_json()["id"]
+
+        meta_resp = client.get(f"/api/attachments/{att_id}/metadata")
+        assert meta_resp.status_code == 200
+
+        download_resp = client.get(f"/api/attachments/{att_id}")
+        assert download_resp.status_code == 200
+        assert download_resp.data == content
+
+        del_resp = client.delete(f"/api/attachments/{att_id}")
+        assert del_resp.status_code == 204
+
+        get_resp = client.get(f"/api/attachments/{att_id}")
+        assert get_resp.status_code == 404
+
+    def test_multiple_uploads_isolation(self, client):
+        ids = []
+        for i in range(3):
+            content = f"file-{i}".encode()
+            data = {
+                "file": (
+                    io.BytesIO(content),
+                    f"file{i}.txt",
+                    "text/plain",
+                )
+            }
+            resp = client.post(
+                "/api/attachments",
+                data=data,
+                content_type="multipart/form-data",
+            )
+            assert resp.status_code == 201
+            ids.append(resp.get_json()["id"])
+
+        # delete the middle one
+        client.delete(f"/api/attachments/{ids[1]}")
+
+        assert client.get(f"/api/attachments/{ids[0]}").status_code == 200
+        assert client.get(f"/api/attachments/{ids[1]}").status_code == 404
+        assert client.get(f"/api/attachments/{ids[2]}").status_code == 200

--- a/backend/tests/test_attachment_model.py
+++ b/backend/tests/test_attachment_model.py
@@ -77,13 +77,15 @@ class TestAttachmentSerialization:
         assert restored.metadata == {"width": 1920, "height": 1080}
 
     def test_round_trip_all_fields(self):
-        att = _make_attachment({
-            "filename": "report.pdf",
-            "mime_type": "application/pdf",
-            "size": 2048,
-            "checksum": "xyz789",
-            "metadata": {"page_count": 3},
-        })
+        att = _make_attachment(
+            {
+                "filename": "report.pdf",
+                "mime_type": "application/pdf",
+                "size": 2048,
+                "checksum": "xyz789",
+                "metadata": {"page_count": 3},
+            }
+        )
         d = att.to_dict()
         restored = Attachment.from_dict(d)
         assert restored.filename == "report.pdf"
@@ -118,7 +120,7 @@ class TestAttachmentSerialization:
             "checksum": "abc",
             "storage_key": "attachments/uuid.bin",
             "created_at": "2026-07-06T12:00:00Z",
-            "filename": "overridden.txt",
+            "filename": "overridden.txt",  # noqa: F601
         }
         # the second "filename" overrides the first; that's dict behavior
         att = Attachment.from_dict(raw)

--- a/backend/tests/test_attachment_model.py
+++ b/backend/tests/test_attachment_model.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+
+import json
+import uuid
+
+import pytest
+
+from palmshed_ai.conversations import Attachment, ATTACHMENT_SCHEMA_VERSION
+
+
+def _make_attachment(overrides=None):
+    data = {
+        "id": str(uuid.uuid4()),
+        "filename": "photo.png",
+        "mime_type": "image/png",
+        "size": 1024,
+        "checksum": "abc123def456",
+        "storage_key": "attachments/some-uuid.bin",
+        "created_at": "2026-07-06T12:00:00Z",
+    }
+    if overrides:
+        data.update(overrides)
+    return Attachment(**data)
+
+
+class TestAttachmentCreation:
+    def test_minimal_attachment(self):
+        att = _make_attachment()
+        assert isinstance(att.id, str)
+        assert att.filename == "photo.png"
+        assert att.mime_type == "image/png"
+        assert att.size == 1024
+        assert att.checksum == "abc123def456"
+        assert att.storage_key == "attachments/some-uuid.bin"
+        assert att.created_at == "2026-07-06T12:00:00Z"
+        assert att.metadata is None
+        assert att.schema_version == ATTACHMENT_SCHEMA_VERSION
+
+    def test_attachment_with_metadata(self):
+        att = _make_attachment({"metadata": {"source": "upload", "width": 800}})
+        assert att.metadata == {"source": "upload", "width": 800}
+
+    def test_different_mime_types(self):
+        for mime in ("image/png", "image/jpeg", "application/pdf", "text/plain"):
+            att = _make_attachment({"mime_type": mime})
+            assert att.mime_type == mime
+
+    def test_zero_size_allowed(self):
+        att = _make_attachment({"size": 0})
+        assert att.size == 0
+
+    def test_large_size(self):
+        att = _make_attachment({"size": 10_000_000})
+        assert att.size == 10_000_000
+
+
+class TestAttachmentSerialization:
+    def test_round_trip_minimal(self):
+        att = _make_attachment()
+        d = att.to_dict()
+        restored = Attachment.from_dict(d)
+        assert restored.id == att.id
+        assert restored.filename == att.filename
+        assert restored.mime_type == att.mime_type
+        assert restored.size == att.size
+        assert restored.checksum == att.checksum
+        assert restored.storage_key == att.storage_key
+        assert restored.created_at == att.created_at
+        assert restored.metadata is None
+        assert restored.schema_version == ATTACHMENT_SCHEMA_VERSION
+
+    def test_round_trip_with_metadata(self):
+        att = _make_attachment({"metadata": {"width": 1920, "height": 1080}})
+        d = att.to_dict()
+        restored = Attachment.from_dict(d)
+        assert restored.metadata == {"width": 1920, "height": 1080}
+
+    def test_round_trip_all_fields(self):
+        att = _make_attachment({
+            "filename": "report.pdf",
+            "mime_type": "application/pdf",
+            "size": 2048,
+            "checksum": "xyz789",
+            "metadata": {"page_count": 3},
+        })
+        d = att.to_dict()
+        restored = Attachment.from_dict(d)
+        assert restored.filename == "report.pdf"
+        assert restored.mime_type == "application/pdf"
+        assert restored.size == 2048
+        assert restored.checksum == "xyz789"
+        assert restored.metadata == {"page_count": 3}
+
+    def test_unknown_fields_preserved(self):
+        raw = {
+            "id": str(uuid.uuid4()),
+            "filename": "doc.txt",
+            "mime_type": "text/plain",
+            "size": 512,
+            "checksum": "abc",
+            "storage_key": "attachments/uuid.bin",
+            "created_at": "2026-07-06T12:00:00Z",
+            "future_field": "something new",
+            "another_field": 42,
+        }
+        att = Attachment.from_dict(raw)
+        d = att.to_dict()
+        assert d["future_field"] == "something new"
+        assert d["another_field"] == 42
+
+    def test_unknown_fields_do_not_leak_into_known(self):
+        raw = {
+            "id": str(uuid.uuid4()),
+            "filename": "doc.txt",
+            "mime_type": "text/plain",
+            "size": 512,
+            "checksum": "abc",
+            "storage_key": "attachments/uuid.bin",
+            "created_at": "2026-07-06T12:00:00Z",
+            "filename": "overridden.txt",
+        }
+        # the second "filename" overrides the first; that's dict behavior
+        att = Attachment.from_dict(raw)
+        assert att.filename == "overridden.txt"
+
+    def test_json_round_trip(self):
+        att = _make_attachment({"metadata": {"key": "val"}})
+        raw_json = json.dumps(att.to_dict())
+        restored = Attachment.from_dict(json.loads(raw_json))
+        assert restored.id == att.id
+        assert restored.filename == att.filename
+        assert restored.checksum == att.checksum
+        assert restored.metadata == {"key": "val"}
+
+    def test_metadata_excluded_when_empty(self):
+        att = _make_attachment()
+        att.metadata = None
+        d = att.to_dict()
+        assert "metadata" not in d or d["metadata"] is None
+
+
+class TestSchemaVersioning:
+    def test_current_version(self):
+        assert ATTACHMENT_SCHEMA_VERSION == 1
+
+    def test_schema_version_in_output(self):
+        att = _make_attachment()
+        d = att.to_dict()
+        assert d["schema_version"] == ATTACHMENT_SCHEMA_VERSION
+
+    def test_older_version_loads(self):
+        raw = {
+            "id": str(uuid.uuid4()),
+            "filename": "old.txt",
+            "mime_type": "text/plain",
+            "size": 100,
+            "checksum": "old",
+            "storage_key": "attachments/old.bin",
+            "created_at": "2026-07-06T12:00:00Z",
+            "schema_version": 0,
+        }
+        att = Attachment.from_dict(raw)
+        assert att.schema_version == 0
+
+    def test_missing_schema_defaults_to_zero(self):
+        raw = {
+            "id": str(uuid.uuid4()),
+            "filename": "noversion.txt",
+            "mime_type": "text/plain",
+            "size": 100,
+            "checksum": "none",
+            "storage_key": "attachments/none.bin",
+            "created_at": "2026-07-06T12:00:00Z",
+        }
+        att = Attachment.from_dict(raw)
+        assert att.schema_version == 0
+
+    def test_future_schema_version_raises(self):
+        raw = {
+            "id": str(uuid.uuid4()),
+            "filename": "future.txt",
+            "mime_type": "text/plain",
+            "size": 100,
+            "checksum": "future",
+            "storage_key": "attachments/future.bin",
+            "created_at": "2026-07-06T12:00:00Z",
+            "schema_version": 999,
+        }
+        with pytest.raises(ValueError, match="newer"):
+            Attachment.from_dict(raw)
+
+
+class TestImmutability:
+    def test_to_dict_returns_new_dict(self):
+        att = _make_attachment()
+        d1 = att.to_dict()
+        d1["filename"] = "modified.png"
+        assert att.filename != "modified.png"
+        d2 = att.to_dict()
+        assert d2["filename"] == "photo.png"
+
+    def test_from_dict_deep_copies_metadata(self):
+        raw = {
+            "id": str(uuid.uuid4()),
+            "filename": "test.txt",
+            "mime_type": "text/plain",
+            "size": 100,
+            "checksum": "abc",
+            "storage_key": "attachments/t.bin",
+            "created_at": "2026-07-06T12:00:00Z",
+            "metadata": {"nested": {"key": "val"}},
+        }
+        att = Attachment.from_dict(raw)
+        raw["metadata"]["nested"]["key"] = "changed"
+        assert att.metadata["nested"]["key"] == "val"
+
+    def test_to_dict_deep_copies_metadata(self):
+        att = _make_attachment({"metadata": {"nested": {"key": "val"}}})
+        d = att.to_dict()
+        d["metadata"]["nested"]["key"] = "changed"
+        assert att.metadata["nested"]["key"] == "val"
+
+
+class TestIdentifier:
+    def test_id_is_non_empty_string(self):
+        att = _make_attachment()
+        assert isinstance(att.id, str)
+        assert len(att.id) > 0
+
+    def test_uuid_format(self):
+        att = _make_attachment()
+        parsed = uuid.UUID(att.id)
+        assert str(parsed) == att.id
+
+
+class TestTimestampFormat:
+    def test_iso_8601_utc(self):
+        att = _make_attachment()
+        assert att.created_at.endswith("Z")
+        assert "T" in att.created_at
+
+
+class TestChecksum:
+    def test_checksum_is_string(self):
+        att = _make_attachment()
+        assert isinstance(att.checksum, str)
+        assert len(att.checksum) > 0
+
+    def test_empty_checksum_allowed(self):
+        att = _make_attachment({"checksum": ""})
+        assert att.checksum == ""
+
+
+class TestStorageKey:
+    def test_storage_key_is_string(self):
+        att = _make_attachment()
+        assert isinstance(att.storage_key, str)
+        assert len(att.storage_key) > 0
+
+    def test_storage_key_preserved(self):
+        key = "custom/path/file.bin"
+        att = _make_attachment({"storage_key": key})
+        assert att.storage_key == key
+
+
+class TestSizeType:
+    def test_size_is_int(self):
+        att = _make_attachment()
+        assert isinstance(att.size, int)
+
+    def test_negative_size_allowed_at_model(self):
+        att = _make_attachment({"size": -1})
+        assert att.size == -1

--- a/backend/tests/test_attachment_store.py
+++ b/backend/tests/test_attachment_store.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+
+import uuid
+
+from services.storage import StorageService, StorageConfig
+
+from palmshed_ai.conversations import Attachment, AttachmentStore
+
+
+def _make_attachment(overrides=None) -> Attachment:
+    data = {
+        "id": str(uuid.uuid4()),
+        "filename": "photo.png",
+        "mime_type": "image/png",
+        "size": 1024,
+        "checksum": "abc123",
+        "storage_key": f"attachments/{uuid.uuid4()}.bin",
+        "created_at": "2026-07-06T12:00:00Z",
+    }
+    if overrides:
+        data.update(overrides)
+    return Attachment(**data)
+
+
+def _make_store() -> tuple[AttachmentStore, StorageService]:
+    config = StorageConfig(provider="mock", bucket="alma-test")
+    storage = StorageService(config=config)
+    store = AttachmentStore(storage=storage)
+    return store, storage
+
+
+class TestAttachmentStoreSave:
+    def test_save_and_load_metadata(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"fake-image-data")
+        loaded = store.load_metadata(att.id)
+        assert loaded is not None
+        assert loaded.id == att.id
+        assert loaded.filename == att.filename
+        assert loaded.mime_type == att.mime_type
+        assert loaded.size == att.size
+        assert loaded.checksum == att.checksum
+
+    def test_save_and_load_data(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        data = b"hello-world-data"
+        store.save(att, data)
+        loaded_data = store.load_data(att.id)
+        assert loaded_data == data
+
+    def test_save_and_load_with_data(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        data = b"complete-data"
+        store.save(att, data)
+        result = store.load_with_data(att.id)
+        assert result is not None
+        loaded_att, loaded_data = result
+        assert loaded_att.id == att.id
+        assert loaded_data == data
+
+    def test_save_multiple_attachments(self):
+        store, _storage = _make_store()
+        att1 = _make_attachment()
+        att2 = _make_attachment()
+        store.save(att1, b"data1")
+        store.save(att2, b"data2")
+        assert store.load_metadata(att1.id) is not None
+        assert store.load_metadata(att2.id) is not None
+        assert store.load_data(att1.id) == b"data1"
+        assert store.load_data(att2.id) == b"data2"
+
+    def test_save_preserves_metadata(self):
+        store, _storage = _make_store()
+        att = _make_attachment({"metadata": {"width": 800, "height": 600}})
+        store.save(att, b"data")
+        loaded = store.load_metadata(att.id)
+        assert loaded is not None
+        assert loaded.metadata == {"width": 800, "height": 600}
+
+    def test_save_large_data(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        large_data = b"x" * 100_000
+        store.save(att, large_data)
+        loaded = store.load_data(att.id)
+        assert loaded == large_data
+
+
+
+
+class TestAttachmentStoreLoad:
+    def test_load_nonexistent_metadata_returns_none(self):
+        store, _storage = _make_store()
+        result = store.load_metadata("nonexistent-id")
+        assert result is None
+
+    def test_load_nonexistent_data_returns_none(self):
+        store, _storage = _make_store()
+        result = store.load_data("nonexistent-id")
+        assert result is None
+
+    def test_load_nonexistent_with_data_returns_none(self):
+        store, _storage = _make_store()
+        result = store.load_with_data("nonexistent-id")
+        assert result is None
+
+    def test_load_after_delete_returns_none(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        store.delete(att.id)
+        assert store.load_metadata(att.id) is None
+
+    def test_load_data_after_metadata_deleted_returns_none(self):
+        store, storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        # manually delete metadata
+        storage.delete(store._metadata_path(att.id))
+        result = store.load_with_data(att.id)
+        assert result is None
+
+
+class TestAttachmentStoreDelete:
+    def test_delete_removes_both(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        assert store.metadata_exists(att.id)
+        assert store.binary_exists(att.id)
+        store.delete(att.id)
+        assert not store.metadata_exists(att.id)
+        assert not store.binary_exists(att.id)
+
+    def test_delete_nonexistent_returns_false(self):
+        store, _storage = _make_store()
+        result = store.delete("nonexistent")
+        assert result is False
+
+    def test_delete_twice_idempotent(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        store.delete(att.id)
+        result = store.delete(att.id)
+        assert result is False
+
+    def test_delete_only_metadata(self):
+        store, storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        storage.delete(store._binary_path(att.id))
+        result = store.delete(att.id)
+        assert result is True
+        assert not store.metadata_exists(att.id)
+
+
+class TestAttachmentStoreList:
+    def test_list_empty(self):
+        store, _storage = _make_store()
+        ids = store.list_ids()
+        assert ids == []
+
+    def test_list_single(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        ids = store.list_ids()
+        assert att.id in ids
+
+    def test_list_multiple(self):
+        store, _storage = _make_store()
+        ids_expected = set()
+        for _ in range(5):
+            att = _make_attachment()
+            store.save(att, b"data")
+            ids_expected.add(att.id)
+        ids_found = set(store.list_ids())
+        assert ids_found == ids_expected
+
+    def test_list_after_delete(self):
+        store, _storage = _make_store()
+        att1 = _make_attachment()
+        att2 = _make_attachment()
+        store.save(att1, b"data1")
+        store.save(att2, b"data2")
+        store.delete(att1.id)
+        ids = store.list_ids()
+        assert att1.id not in ids
+        assert att2.id in ids
+
+    def test_list_returns_sorted(self):
+        store, _storage = _make_store()
+        atts = [_make_attachment() for _ in range(3)]
+        for att in atts:
+            store.save(att, b"data")
+        ids = store.list_ids()
+        assert ids == sorted(ids)
+
+
+class TestAttachmentStoreExistence:
+    def test_metadata_exists(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        assert store.metadata_exists(att.id)
+
+    def test_metadata_not_exists(self):
+        store, _storage = _make_store()
+        assert not store.metadata_exists("nonexistent")
+
+    def test_binary_exists(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        assert store.binary_exists(att.id)
+
+    def test_binary_not_exists(self):
+        store, _storage = _make_store()
+        assert not store.binary_exists("nonexistent")
+
+
+class TestAttachmentStorePaths:
+    def test_binary_path_format(self):
+        att_id = str(uuid.uuid4())
+        path = AttachmentStore._binary_path(att_id)
+        assert path == f"attachments/{att_id}.bin"
+
+    def test_metadata_path_format(self):
+        att_id = str(uuid.uuid4())
+        path = AttachmentStore._metadata_path(att_id)
+        assert path == f"attachment-metadata/{att_id}.json"
+
+
+class TestAttachmentStoreIsolation:
+    def test_different_attachments_dont_interfere(self):
+        store, _storage = _make_store()
+        att1 = _make_attachment()
+        att2 = _make_attachment()
+        store.save(att1, b"data1")
+        store.save(att2, b"data2")
+        store.delete(att1.id)
+        assert store.load_metadata(att2.id) is not None
+        assert store.load_data(att2.id) == b"data2"
+
+    def test_save_overwrites_existing(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"original")
+        store.save(att, b"updated")
+        assert store.load_data(att.id) == b"updated"

--- a/backend/tests/test_attachment_store.py
+++ b/backend/tests/test_attachment_store.py
@@ -90,8 +90,6 @@ class TestAttachmentStoreSave:
         assert loaded == large_data
 
 
-
-
 class TestAttachmentStoreLoad:
     def test_load_nonexistent_metadata_returns_none(self):
         store, _storage = _make_store()
@@ -253,3 +251,51 @@ class TestAttachmentStoreIsolation:
         store.save(att, b"original")
         store.save(att, b"updated")
         assert store.load_data(att.id) == b"updated"
+
+
+class TestAttachmentStoreUpdateMetadata:
+    def test_update_metadata_adds_keys(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        result = store.update_metadata(
+            att.id, {"conversation_id": "conv-1", "message_id": "msg-1"}
+        )
+        assert result is True
+        loaded = store.load_metadata(att.id)
+        assert loaded is not None
+        assert loaded.metadata == {"conversation_id": "conv-1", "message_id": "msg-1"}
+
+    def test_update_metadata_merges_with_existing(self):
+        store, _storage = _make_store()
+        att = _make_attachment({"metadata": {"width": 800}})
+        store.save(att, b"data")
+        store.update_metadata(att.id, {"conversation_id": "conv-1"})
+        loaded = store.load_metadata(att.id)
+        assert loaded is not None
+        assert loaded.metadata == {"width": 800, "conversation_id": "conv-1"}
+
+    def test_update_metadata_nonexistent_returns_false(self):
+        store, _storage = _make_store()
+        result = store.update_metadata("nonexistent", {"conversation_id": "x"})
+        assert result is False
+
+    def test_update_metadata_idempotent(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        store.update_metadata(att.id, {"conversation_id": "conv-1"})
+        store.update_metadata(att.id, {"conversation_id": "conv-1"})
+        loaded = store.load_metadata(att.id)
+        assert loaded is not None
+        assert loaded.metadata == {"conversation_id": "conv-1"}
+
+    def test_update_metadata_overwrites_key(self):
+        store, _storage = _make_store()
+        att = _make_attachment()
+        store.save(att, b"data")
+        store.update_metadata(att.id, {"conversation_id": "conv-1"})
+        store.update_metadata(att.id, {"conversation_id": "conv-2"})
+        loaded = store.load_metadata(att.id)
+        assert loaded is not None
+        assert loaded.metadata == {"conversation_id": "conv-2"}

--- a/backend/verify.py
+++ b/backend/verify.py
@@ -592,6 +592,179 @@ def check_persistence() -> Dict[str, Any]:
     return result
 
 
+def check_attachments() -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "name": "attachments",
+        "label": "Attachment Lifecycle",
+        "group": "platform",
+        "status": "fail",
+    }
+    t0 = time.time()
+    try:
+        import uuid
+        from services import platform
+        from palmshed_ai.conversations import (
+            Attachment,
+            AttachmentStore,
+            Conversation,
+            Message,
+            ConversationStore,
+        )
+
+        att_store = AttachmentStore(storage=platform.storage)
+        conv_store = ConversationStore(
+            storage=platform.storage, owner_id="verify-attachments"
+        )
+
+        # 1. Upload image
+        png_data = b"\x89PNG\r\n\x1a\n" + b"fake-pixel-data"
+        img_att = Attachment(
+            id=str(uuid.uuid4()),
+            filename="verify.png",
+            mime_type="image/png",
+            size=len(png_data),
+            checksum="abc123",
+            storage_key=f"attachments/{uuid.uuid4()}.bin",
+            created_at="2026-07-07T12:00:00Z",
+        )
+        att_store.save(img_att, png_data)
+
+        # 2. Upload PDF
+        pdf_data = b"%PDF-1.4 fake document content"
+        pdf_att = Attachment(
+            id=str(uuid.uuid4()),
+            filename="verify.pdf",
+            mime_type="application/pdf",
+            size=len(pdf_data),
+            checksum="def456",
+            storage_key=f"attachments/{uuid.uuid4()}.bin",
+            created_at="2026-07-07T12:00:00Z",
+        )
+        att_store.save(pdf_att, pdf_data)
+
+        # 3. Create conversation with a message referencing both
+        msg = Message(
+            id=str(uuid.uuid4()),
+            role="user",
+            timestamp="2026-07-07T12:00:00Z",
+            content="Verify attachment lifecycle",
+            attachments=[
+                {
+                    "id": img_att.id,
+                    "filename": "verify.png",
+                    "mime_type": "image/png",
+                    "size": len(png_data),
+                },
+                {
+                    "id": pdf_att.id,
+                    "filename": "verify.pdf",
+                    "mime_type": "application/pdf",
+                    "size": len(pdf_data),
+                },
+            ],
+        )
+        conv_id = str(uuid.uuid4())
+        conv = Conversation(
+            id=conv_id,
+            title="Verify attachments",
+            mode="chat",
+            created_at="2026-07-07T12:00:00Z",
+            updated_at="2026-07-07T12:00:00Z",
+            messages=[msg],
+        )
+
+        # 4. Populate references and save
+        conv_store.create(conv)
+        for ref in msg.attachments:
+            att_store.update_metadata(
+                ref["id"],
+                {
+                    "conversation_id": conv_id,
+                    "message_id": msg.id,
+                },
+            )
+
+        # 5. Verify metadata populated
+        loaded_img = att_store.load_metadata(img_att.id)
+        if loaded_img is None:
+            result["error"] = "Image metadata not found after save"
+            return result
+        refs = loaded_img.metadata or {}
+        if refs.get("conversation_id") != conv_id:
+            result["error"] = (
+                f"Image conversation_id mismatch: "
+                f"{refs.get('conversation_id')} != {conv_id}"
+            )
+            return result
+        if refs.get("message_id") != msg.id:
+            result["error"] = (
+                f"Image message_id mismatch: {refs.get('message_id')} != {msg.id}"
+            )
+            return result
+
+        # 6. Reload conversation and verify attachments restored
+        loaded_conv = conv_store.load(conv_id)
+        if loaded_conv is None:
+            result["error"] = "Conversation not found after reload"
+            return result
+        if len(loaded_conv.messages) != 1:
+            result["error"] = f"Expected 1 message, got {len(loaded_conv.messages)}"
+            return result
+        loaded_msg = loaded_conv.messages[0]
+        if len(loaded_msg.attachments or []) != 2:
+            result["error"] = (
+                f"Expected 2 attachments, got {len(loaded_msg.attachments or [])}"
+            )
+            return result
+        loaded_ids = {a["id"] for a in loaded_msg.attachments}
+        if img_att.id not in loaded_ids or pdf_att.id not in loaded_ids:
+            result["error"] = "Attachment IDs mismatch after reload"
+            return result
+
+        # 7. Delete conversation — clean up attachments first
+        for att_ref in msg.attachments:
+            att_store.delete(att_ref["id"])
+        conv_store.delete(conv_id)
+
+        # 8. Verify attachments removed
+        if att_store.metadata_exists(img_att.id):
+            result["error"] = "Image metadata still exists after conversation delete"
+            return result
+        if att_store.binary_exists(img_att.id):
+            result["error"] = "Image binary still exists after conversation delete"
+            return result
+        if att_store.metadata_exists(pdf_att.id):
+            result["error"] = "PDF metadata still exists after conversation delete"
+            return result
+        if att_store.binary_exists(pdf_att.id):
+            result["error"] = "PDF binary still exists after conversation delete"
+            return result
+
+        # 9. Verify no orphaned files
+        remaining = att_store.list_ids()
+        if remaining:
+            result["error"] = f"Orphaned attachments remain after cleanup: {remaining}"
+            return result
+
+        elapsed = round(time.time() - t0, 1)
+        result["status"] = "pass"
+        result["latency"] = elapsed
+        result["details"] = {
+            "lifecycle": (
+                "upload image → upload PDF → create conversation → "
+                "populate references → reload → verify attachments restored → "
+                "delete conversation attachments → delete conversation → "
+                "verify cleanup → no orphans"
+            ),
+        }
+
+    except Exception as exc:
+        elapsed = round(time.time() - t0, 1)
+        result["latency"] = elapsed
+        result["error"] = str(exc)
+    return result
+
+
 def check_identity() -> Dict[str, Any]:
     result: Dict[str, Any] = {
         "name": "identity",
@@ -771,6 +944,7 @@ PLATFORM_CHECKS: Dict[str, Any] = {
     "notifications": check_notifications,
     "persistence": check_persistence,
     "identity": check_identity,
+    "attachments": check_attachments,
 }
 
 APPLICATION_CHECKS: Dict[str, Any] = {
@@ -963,7 +1137,7 @@ def main() -> None:
     group.add_argument(
         "--platform",
         action="store_true",
-        help="Run only platform checks (mail, auth, storage, notifications)",
+        help="Run only platform checks (mail, auth, storage, notifications, persistence, identity, attachments)",
     )
     group.add_argument(
         "--application",

--- a/deploy/static/web/index.html
+++ b/deploy/static/web/index.html
@@ -97,6 +97,7 @@ SPDX-License-Identifier: MIT
                     </div>
                     <div class="composer-loading-bar" id="landing-loading-bar" style="display:none"></div>
                 </div>
+                <div class="pending-attachments" id="landing-pending-attachments" style="display:none"></div>
 
                 <div class="landing-suggestions" id="input-suggestions">
                     <button class="chip tab-canvas" data-text="Summarize this article">Summarize this article</button>
@@ -190,8 +191,14 @@ SPDX-License-Identifier: MIT
         </div>
 
         <div class="conversation-composer">
+            <div class="pending-attachments" id="conv-pending-attachments" style="display:none"></div>
             <div class="composer">
                 <div class="composer-input-row">
+                    <button class="composer-btn composer-btn--attach" id="conv-attach-button" type="button" aria-label="Attach file">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
+                            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+                        </svg>
+                    </button>
                     <textarea class="composer-textarea" id="conversation-input" placeholder="Ask anything..." rows="1"></textarea>
                     <div class="composer-actions">
                         <button class="composer-btn composer-btn--send" id="conversation-submit" type="submit" aria-label="Send message">

--- a/deploy/static/web/static/css/main.css
+++ b/deploy/static/web/static/css/main.css
@@ -12,6 +12,7 @@
   --text-muted: #71717a;
   --accent: #24d455;
   --accent-hover: #1fbf4a;
+  --danger: #e53e3e;
 
   /* Typography */
   --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -526,7 +527,7 @@ body:has(#landing[style*="display:none"]) .app-header-title {
 }
 
 .composer-btn--send.has-text:hover {
-  background: rgba(36, 212, 85, 0.08);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 /* ── Segmented Control ── */
@@ -566,7 +567,7 @@ body:has(#landing[style*="display:none"]) .app-header-title {
 .segmented-control-btn.active {
   color: var(--accent);
   font-weight: 500;
-  background: rgba(36, 212, 85, 0.08);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .segmented-control-btn.active .segmented-control-icon {
@@ -979,7 +980,8 @@ body:has(#landing[style*="display:none"]) .app-header-title {
   transform: translate(-50%, -50%);
   background: var(--bg);
   border: 1px solid var(--border-subtle);
-  border-radius: 20px;
+  border-radius: var(--radius-card);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   padding: 24px 28px;
   z-index: 1001;
   min-width: 320px;
@@ -1009,6 +1011,16 @@ body:has(#landing[style*="display:none"]) .app-header-title {
   padding: 8px 20px;
   background: var(--bg);
   border: 1px solid var(--border-subtle);
+}
+
+.dialog-btn--confirm {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.dialog-btn--confirm:hover {
+  background: var(--accent-hover);
 }
 
 .sidebar-new-chat {
@@ -1166,7 +1178,7 @@ body:has(#landing[style*="display:none"]) .app-header-title {
   color: var(--danger, #e53e3e);
   padding: 8px 12px;
   text-align: center;
-  background: rgba(229, 62, 62, 0.1);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
   border-radius: 6px;
   margin: 4px 12px;
 }
@@ -1246,4 +1258,87 @@ body:has(#landing[style*="display:none"]) .app-header-title {
   width: 100%;
   max-width: 400px;
   height: 40px;
+}
+
+/* ── Pending Attachments ── */
+
+.pending-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 24px 8px;
+}
+
+/* ── Attachment Chip ── */
+
+.attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-chip);
+  padding: 3px 10px;
+  white-space: nowrap;
+  cursor: default;
+}
+
+a.attachment-chip {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a.attachment-chip:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.attachment-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 1px;
+  margin-left: 2px;
+  border-radius: 4px;
+  line-height: 0;
+}
+
+.attachment-chip-remove:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+/* ── Message Attachments ── */
+
+.message-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 20px 4px;
+}
+
+.attachment-image-link {
+  display: inline-block;
+  line-height: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  transition: opacity 0.15s;
+}
+
+.attachment-image-link:hover {
+  opacity: 0.85;
+}
+
+.attachment-image {
+  max-width: 240px;
+  max-height: 180px;
+  object-fit: cover;
+  display: block;
 }

--- a/deploy/static/web/static/js/main.js
+++ b/deploy/static/web/static/js/main.js
@@ -73,6 +73,101 @@ function showSidebarError(msg) {
   setTimeout(function () { el.style.display = 'none'; }, 4000);
 }
 
+/* ── Attachment Handling ── */
+
+function uploadAttachment(file) {
+  return new Promise(function (resolve, reject) {
+    var formData = new FormData();
+    formData.append('file', file);
+    fetch('/api/attachments', {
+      method: 'POST',
+      body: formData,
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (d) { throw new Error(d.error || 'Upload failed'); });
+      return r.json();
+    }).then(resolve).catch(reject);
+  });
+}
+
+function deleteAttachment(id) {
+  return fetch('/api/attachments/' + encodeURIComponent(id), {
+    method: 'DELETE',
+  }).then(function (r) {
+    if (!r.ok && r.status !== 404) throw new Error('Failed to delete attachment');
+  });
+}
+
+function handleFilesSelected(fileList) {
+  var files = Array.from(fileList);
+  function uploadNext() {
+    if (files.length === 0) return;
+    var file = files.shift();
+    uploadAttachment(file).then(function (att) {
+      pendingAttachments.push(att);
+      renderPendingAttachments();
+      uploadNext();
+    }).catch(function (err) {
+      console.error('Upload failed:', file.name, err);
+      uploadNext();
+    });
+  }
+  uploadNext();
+}
+
+function renderPendingAttachments() {
+  var landingContainer = document.getElementById('landing-pending-attachments');
+  var convContainer = document.getElementById('conv-pending-attachments');
+  if (pendingAttachments.length === 0) {
+    if (landingContainer) landingContainer.style.display = 'none';
+    if (convContainer) convContainer.style.display = 'none';
+    return;
+  }
+  var html = '';
+  pendingAttachments.forEach(function (att) {
+    html += '<span class="attachment-chip">' +
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" width="12" height="12">' +
+      '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" /></svg>' +
+      escapeHtml(att.filename) +
+      '<button class="attachment-chip-remove" data-attachment-id="' + att.id + '" type="button" aria-label="Remove ' + escapeHtml(att.filename) + '">' +
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" width="10" height="10">' +
+      '<path d="M18 6 6 18" /><path d="m6 6 12 12" /></svg></button></span>';
+  });
+  if (landingContainer) { landingContainer.innerHTML = html; landingContainer.style.display = ''; }
+  if (convContainer) { convContainer.innerHTML = html; convContainer.style.display = ''; }
+
+  /* Wire remove buttons */
+  var removeBtns = (landingContainer || convContainer).querySelectorAll('.attachment-chip-remove');
+  removeBtns.forEach(function (btn) {
+    btn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var id = btn.getAttribute('data-attachment-id');
+      removePendingAttachment(id);
+    });
+  });
+}
+
+function removePendingAttachment(id) {
+  var att = null;
+  for (var i = 0; i < pendingAttachments.length; i++) {
+    if (pendingAttachments[i].id === id) {
+      att = pendingAttachments[i];
+      pendingAttachments.splice(i, 1);
+      break;
+    }
+  }
+  renderPendingAttachments();
+  if (att) {
+    deleteAttachment(att.id).catch(function (err) {
+      console.error('Failed to delete attachment:', err);
+    });
+  }
+}
+
+function clearPendingAttachments() {
+  pendingAttachments = [];
+  renderPendingAttachments();
+}
+
 /* ── API Calls ── */
 
 function handleSubmit() {
@@ -93,6 +188,11 @@ function handleSubmit() {
   input.style.height = 'auto';
   if (convInput) convInput.style.height = 'auto';
 
+  var attData = pendingAttachments.length > 0
+    ? pendingAttachments.map(function (a) { return { id: a.id, filename: a.filename, mime_type: a.mime_type, size: a.size }; })
+    : null;
+  clearPendingAttachments();
+
   const { mode, style } = getActiveMode();
   var modeStr = style === 'thinking' ? 'thinking' : style === 'url-context' ? 'web' : mode === 'image' ? 'images' : 'canvas';
 
@@ -109,7 +209,9 @@ function handleSubmit() {
   if (activeConversationId) {
     /* Existing conversation — add user message now */
     var payload = cloneConversation(activeConversationData);
-    payload.messages.push({ role: 'user', content: prompt, timestamp: new Date().toISOString() });
+    var userMsg = { role: 'user', content: prompt, timestamp: new Date().toISOString() };
+    if (attData) userMsg.attachments = attData;
+    payload.messages.push(userMsg);
     payload.metadata = payload.metadata || {};
     payload.metadata.status = 'pending';
     createPromise = fetch('/api/conversations/' + encodeURIComponent(activeConversationId), {
@@ -126,13 +228,15 @@ function handleSubmit() {
   } else {
     /* New conversation — create with user message */
     var title = prompt.slice(0, 60);
+    var userMsg = { role: 'user', content: prompt, timestamp: new Date().toISOString() };
+    if (attData) userMsg.attachments = attData;
     createPromise = fetch('/api/conversations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         title: title,
         mode: modeStr,
-        messages: [{ role: 'user', content: prompt, timestamp: new Date().toISOString() }],
+        messages: [userMsg],
         metadata: { status: 'pending' },
       }),
     }).then(function (r) {
@@ -276,6 +380,7 @@ function hideNewChatDialog() {
 function confirmNewChat() {
   hideNewChatDialog();
   clearResults();
+  clearPendingAttachments();
   setActiveConversationId(null);
   activeConversationData = null;
   switchToLanding();
@@ -295,6 +400,7 @@ var sidebarEditingId = null;
 var sidebarEditTitle = '';
 var sidebarConfirmDeleteId = null;
 var sidebarSearchQuery = '';
+var pendingAttachments = [];
 
 function setActiveConversationId(id) {
   activeConversationId = id;
@@ -628,6 +734,25 @@ function renderConversation() {
   msgs.forEach(function (m) {
     if (m.role === 'user') {
       html += '<div class="user-message">' + escapeHtml(m.content) + '</div>';
+      if (m.attachments && m.attachments.length > 0) {
+        html += '<div class="message-attachments">';
+        for (var ai = 0; ai < m.attachments.length; ai++) {
+          var att = m.attachments[ai];
+          var isImage = att.mime_type && att.mime_type.indexOf('image/') === 0;
+          var attId = encodeURIComponent(att.id || '');
+          var fname = escapeHtml(att.filename || 'file');
+          if (isImage) {
+            html += '<a href="/api/attachments/' + attId + '" target="_blank" rel="noopener noreferrer" class="attachment-image-link">' +
+              '<img src="/api/attachments/' + attId + '" alt="' + fname + '" class="attachment-image" loading="lazy"></a>';
+          } else {
+            html += '<a href="/api/attachments/' + attId + '" target="_blank" rel="noopener noreferrer" class="attachment-chip" download="' + fname + '">' +
+              '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" width="12" height="12">' +
+              '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" /></svg>' +
+              fname + '</a>';
+          }
+        }
+        html += '</div>';
+      }
     } else if (m.role === 'assistant') {
       if (m.thinking) html += '<div class="thinking-container">' + m.thinking + '</div>';
       html += '<div class="response-container">' + (m.content ? marked.parse(m.content) : '') + '</div>';
@@ -747,7 +872,32 @@ document.addEventListener('DOMContentLoaded', function () {
   const convInput = document.getElementById('conversation-input');
   const convSubmit = document.getElementById('conversation-submit');
 
-  /* Segmented control clicks */
+  /* ── Attachment file input ── */
+  var fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.multiple = true;
+  fileInput.accept = 'image/png,image/jpeg,image/webp,image/gif,application/pdf,text/plain,text/markdown';
+  fileInput.style.display = 'none';
+  fileInput.id = 'attachment-file-input';
+  fileInput.addEventListener('change', function (e) {
+    if (e.target.files && e.target.files.length > 0) {
+      handleFilesSelected(e.target.files);
+    }
+    e.target.value = '';
+  });
+  document.body.appendChild(fileInput);
+
+  function triggerFileInput() {
+    fileInput.click();
+  }
+
+  /* Wire attach buttons */
+  var attachBtn = document.getElementById('attach-button');
+  if (attachBtn) attachBtn.addEventListener('click', triggerFileInput);
+  var convAttachBtn = document.getElementById('conv-attach-button');
+  if (convAttachBtn) convAttachBtn.addEventListener('click', triggerFileInput);
+
+  /* ── Segmented control clicks ── */
   document.querySelectorAll('.segmented-control-btn').forEach((btn) => {
     btn.addEventListener('click', function () {
       document.querySelectorAll('.segmented-control-btn').forEach((b) => {

--- a/deploy/static/web/templates/index.html
+++ b/deploy/static/web/templates/index.html
@@ -97,6 +97,7 @@ SPDX-License-Identifier: MIT
                     </div>
                     <div class="composer-loading-bar" id="landing-loading-bar" style="display:none"></div>
                 </div>
+                <div class="pending-attachments" id="landing-pending-attachments" style="display:none"></div>
 
                 <div class="landing-suggestions" id="input-suggestions">
                     <button class="chip tab-canvas" data-text="Summarize this article">Summarize this article</button>
@@ -190,8 +191,14 @@ SPDX-License-Identifier: MIT
         </div>
 
         <div class="conversation-composer">
+            <div class="pending-attachments" id="conv-pending-attachments" style="display:none"></div>
             <div class="composer">
                 <div class="composer-input-row">
+                    <button class="composer-btn composer-btn--attach" id="conv-attach-button" type="button" aria-label="Attach file">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
+                            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+                        </svg>
+                    </button>
                     <textarea class="composer-textarea" id="conversation-input" placeholder="Ask anything..." rows="1"></textarea>
                     <div class="composer-actions">
                         <button class="composer-btn composer-btn--send" id="conversation-submit" type="submit" aria-label="Send message">

--- a/docs/architecture/0007-attachment-model.md
+++ b/docs/architecture/0007-attachment-model.md
@@ -1,0 +1,86 @@
+# ADR 0007: Attachment Model
+
+**Date:** 2026-07-06
+**Status:** Accepted
+
+## Context
+
+Alma needs to attach files to conversations. The design must determine
+where attachments live in the domain model and how they are stored.
+
+## Decision
+
+### Attachments belong to messages, not conversations
+
+Every file has context — it was uploaded as part of a specific message.
+Attaching to the message rather than the conversation keeps the model
+simple and enables:
+
+- **Search** — find files by their surrounding message text
+- **Export** — export a message and its files together
+- **Retrieval** — retrieve files only when the message is loaded
+- **Sharing** — share a message with its attachments intact
+- **Cleanup** — delete files when the message is deleted
+
+A conversation never references attachments directly. It stores
+messages, and messages store attachment IDs.
+
+### Attachment storage is flat and independent of conversation layout
+
+Attachment bytes are stored as:
+
+```
+attachments/<attachment-id>.bin
+```
+
+Metadata is stored as:
+
+```
+attachment-metadata/<attachment-id>.json
+```
+
+The metadata contains `conversation_id` and `message_id` as references,
+not as path components. This avoids baking the conversation hierarchy
+into the storage layer and gives flexibility to:
+
+- **Move a message** between conversations without rewriting file paths
+- **Split conversations** without relocating attachment blobs
+- **Quote or forward messages** with their attachments
+- **Deduplicate files** when the same blob is referenced from multiple
+  messages
+- **Evolve storage independently** of the conversation model
+
+### The Attachment domain object is independent of its relationships
+
+The `Attachment` model contains only its own identity and properties:
+
+- `id` — unique identifier
+- `filename` — original upload name
+- `mime_type` — validated media type
+- `size` — file size in bytes
+- `checksum` — SHA-256 of file bytes
+- `storage_key` — path within the storage provider
+- `created_at` — timestamp
+- `metadata` — optional key-value map for extensibility
+- `schema_version` — for forward compatibility
+- preserved unknown fields — for safe deserialization
+
+The model does not contain `conversation_id` or `message_id`. Those are
+metadata of the *relationship*, not properties of the attachment
+itself. The message that references the attachment owns the
+relationship.
+
+## Consequences
+
+- Attachments are first-class domain objects with their own lifecycle
+  and identity.
+- Messages reference attachments by ID only — the attachment exists
+  independently.
+- Storage layout is flat, making it easy to reorganize conversations
+  without moving file bytes.
+- The same attachment can conceptually be referenced from multiple
+  messages without storage duplication.
+- Adding attachment sharing or deduplication later requires no storage
+  migration.
+- The relationship between attachment, message, and conversation is
+  always explicit in metadata, never implicit in paths.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ import { useComposer } from './hooks/useComposer';
 import { useConversation } from './hooks/useConversation';
 import { MODES, SUGGESTIONS } from './utils';
 import { api } from './services/api';
-import { ConversationData } from './types';
+import { AttachmentData, ConversationData } from './types';
 
 const STORAGE_ACTIVE_CONV = 'alma_active_conversation';
 
@@ -42,6 +42,8 @@ function App() {
   const [theme, setTheme] = useState<'dark' | 'light'>(
     (document.documentElement.getAttribute('data-theme') as 'dark' | 'light') || 'dark'
   );
+  const [pendingAttachments, setPendingAttachments] = useState<AttachmentData[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [activeConversationId, setActiveConversationId] = useState<string | undefined>(undefined);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showNewChatDialog, setShowNewChatDialog] = useState(false);
@@ -143,13 +145,44 @@ function App() {
     document.documentElement.setAttribute('data-theme', next);
   }, [theme]);
 
+  const handleAttach = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    const uploaded: AttachmentData[] = [];
+    for (const file of Array.from(files)) {
+      try {
+        const att = await api.uploadAttachment(file);
+        uploaded.push(att);
+      } catch (err) {
+        console.error('Upload failed:', file.name, err);
+      }
+    }
+    setPendingAttachments(prev => [...prev, ...uploaded]);
+    e.target.value = '';
+  }, []);
+
+  const handleRemoveAttachment = useCallback(async (att: AttachmentData) => {
+    setPendingAttachments(prev => prev.filter(a => a.id !== att.id));
+    try {
+      await api.deleteAttachment(att.id);
+    } catch {
+      /* ignore — server-side cleanup is best-effort */
+    }
+  }, []);
+
   const handleSubmit = useCallback(async (text: string) => {
+    const atts = pendingAttachments.length > 0 ? pendingAttachments : undefined;
     composerClear();
+    setPendingAttachments([]);
     lastPromptRef.current = text;
     try {
       if (activeConversationId) {
         const payload = JSON.parse(JSON.stringify(activeConversationRef.current));
-        payload.messages.push({ role: 'user', content: text, timestamp: new Date().toISOString() });
+        payload.messages.push({ role: 'user', content: text, timestamp: new Date().toISOString(), ...(atts ? { attachments: atts.map(a => ({ id: a.id, filename: a.filename, mime_type: a.mime_type, size: a.size })) } : {}) });
         payload.metadata = { ...(payload.metadata || {}), status: 'pending' };
         const updated = await api.updateConversation(activeConversationId, payload);
         activeConversationRef.current = updated;
@@ -157,7 +190,7 @@ function App() {
         const payload = {
           title: text.slice(0, 60),
           mode,
-          messages: [{ role: 'user', content: text, timestamp: new Date().toISOString() }],
+          messages: [{ role: 'user', content: text, timestamp: new Date().toISOString(), ...(atts ? { attachments: atts.map(a => ({ id: a.id, filename: a.filename, mime_type: a.mime_type, size: a.size })) } : {}) }],
           metadata: { status: 'pending' },
         };
         const conv = await api.createConversation(payload);
@@ -167,8 +200,8 @@ function App() {
     } catch {
       /* Continue anyway — the user's message will be in local state */
     }
-    submit(text, mode, messages);
-  }, [submit, mode, activeConversationId, composerClear, messages]);
+    submit(text, mode, messages, atts);
+  }, [submit, mode, activeConversationId, composerClear, messages, pendingAttachments]);
 
   const handleNewChat = useCallback(() => {
     if (isLoading) return;
@@ -254,6 +287,7 @@ function App() {
       value={input}
       onChange={setInput}
       onSubmit={handleSubmit}
+      onAttach={handleAttach}
       placeholder="Ask anything..."
       loading={isLoading}
       onClear={composerClear}
@@ -273,6 +307,15 @@ function App() {
     <div className="app-container">
       <Header theme={theme} onThemeToggle={handleThemeToggle} onMenuToggle={() => setSidebarOpen(true)} showTitle={conversationStarted} onNewChat={handleNewChat} />
 
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        multiple
+        accept="image/png,image/jpeg,image/webp,image/gif,application/pdf,text/plain,text/markdown"
+        style={{ display: 'none' }}
+      />
+
       {!conversationStarted ? (
         <LandingLayout
           hero={
@@ -286,7 +329,33 @@ function App() {
               <span className="landing-title">Alma</span>
             </>
           }
-          composer={composer}
+          composer={
+            <div className="composer-wrapper">
+              {composer}
+              {pendingAttachments.length > 0 && (
+                <div className="pending-attachments">
+                  {pendingAttachments.map(a => (
+                    <span key={a.id} className="attachment-chip">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" width={12} height={12}>
+                        <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+                      </svg>
+                      {a.filename}
+                      <button
+                        className="attachment-chip-remove"
+                        onClick={() => handleRemoveAttachment(a)}
+                        type="button"
+                        aria-label={`Remove ${a.filename}`}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" width={10} height={10}>
+                          <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+                        </svg>
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          }
           suggestions={
             !input && suggestions.length > 0 ? (
               <div className="landing-suggestions">
@@ -311,7 +380,36 @@ function App() {
             <>
               {messages.map((msg, i) => {
                 if (msg.role === 'user') {
-                  return <UserMessage key={i} content={msg.content} />;
+                  return (
+                    <div key={i}>
+                      <UserMessage content={msg.content} />
+                      {msg.attachments && msg.attachments.length > 0 && (
+                        <div className="message-attachments">
+                          {msg.attachments.map((att: Record<string, unknown>) => {
+                            const isImage = typeof att.mime_type === 'string' && att.mime_type.startsWith('image/');
+                            const attId = typeof att.id === 'string' ? att.id : '';
+                            const filename = typeof att.filename === 'string' ? att.filename : 'file';
+                            const mime = typeof att.mime_type === 'string' ? att.mime_type : '';
+                            if (isImage) {
+                              return (
+                                <a key={attId} href={`/api/attachments/${attId}`} target="_blank" rel="noopener noreferrer" className="attachment-image-link">
+                                  <img src={`/api/attachments/${attId}`} alt={filename} className="attachment-image" loading="lazy" />
+                                </a>
+                              );
+                            }
+                            return (
+                              <a key={attId} href={`/api/attachments/${attId}`} target="_blank" rel="noopener noreferrer" className="attachment-chip" download={filename}>
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" width={12} height={12}>
+                                  <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+                                </svg>
+                                {filename}
+                              </a>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
                 }
                 if (msg.role === 'assistant') {
                   return (
@@ -342,7 +440,31 @@ function App() {
           }
           composer={
             <>
-              {composer}
+              <div className="composer-wrapper">
+                {composer}
+                {pendingAttachments.length > 0 && (
+                  <div className="pending-attachments">
+                    {pendingAttachments.map(a => (
+                      <span key={a.id} className="attachment-chip">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" width={12} height={12}>
+                          <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+                        </svg>
+                        {a.filename}
+                        <button
+                          className="attachment-chip-remove"
+                          onClick={() => handleRemoveAttachment(a)}
+                          type="button"
+                          aria-label={`Remove ${a.filename}`}
+                        >
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" width={10} height={10}>
+                            <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+                          </svg>
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
               <SegmentedControl
                 options={MODES}
                 value={mode}

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -1,13 +1,13 @@
 import { useState, useCallback } from 'react';
 import { api } from '../services/api';
-import type { MessageData, ConversationData } from '../types';
+import type { AttachmentData, MessageData, ConversationData } from '../types';
 
 interface UseConversationReturn {
   messages: MessageData[];
   isLoading: boolean;
   conversationStarted: boolean;
   error: string | null;
-  submit: (text: string, mode: string, convMessages?: MessageData[]) => Promise<void>;
+  submit: (text: string, mode: string, convMessages?: MessageData[], attachments?: AttachmentData[]) => Promise<void>;
   clear: () => void;
   loadConversation: (conv: ConversationData) => void;
   reconcileMessages: (newMessages: MessageData[]) => void;
@@ -20,14 +20,16 @@ export function useConversation(): UseConversationReturn {
 
   const conversationStarted = messages.length > 0 || isLoading;
 
-  const submit = useCallback(async (text: string, mode: string, convMessages?: MessageData[]) => {
+  const submit = useCallback(async (text: string, mode: string, convMessages?: MessageData[], attachments?: AttachmentData[]) => {
     if (!text.trim() || isLoading) return;
     setIsLoading(true);
     setError(null);
 
     const ts = new Date().toISOString();
+    const attData = attachments?.map(a => ({ id: a.id, filename: a.filename, mime_type: a.mime_type, size: a.size }));
     const userMsg: MessageData = {
       id: '', role: 'user', content: text, timestamp: ts,
+      ...(attData && attData.length > 0 ? { attachments: attData as unknown as Record<string, unknown>[] } : {}),
     };
     setMessages(prev => [...prev, userMsg]);
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,6 +12,7 @@
   --text-muted: #71717a;
   --accent: #24d455;
   --accent-hover: #1fbf4a;
+  --danger: #e53e3e;
 
   /* Typography */
   --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -561,7 +562,7 @@ html {
 }
 
 .composer-btn--send.has-text:hover {
-  background: rgba(36, 212, 85, 0.08);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .composer-loading-bar {
@@ -641,7 +642,7 @@ html {
 .segmented-control-btn.active {
   color: var(--accent);
   font-weight: 500;
-  background: rgba(36, 212, 85, 0.08);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .segmented-control-btn.active .segmented-control-icon {
@@ -688,7 +689,7 @@ html {
 .chip--selected {
   color: var(--accent);
   border-color: var(--accent);
-  background: rgba(36, 212, 85, 0.08);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 /* ── Loading Dots ── */
@@ -833,7 +834,8 @@ html {
   transform: translate(-50%, -50%);
   background: var(--bg);
   border: 1px solid var(--border-subtle);
-  border-radius: 20px;
+  border-radius: var(--radius-card);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   padding: 24px 28px;
   z-index: 1001;
   min-width: 320px;
@@ -865,6 +867,16 @@ html {
   border: 1px solid var(--border-subtle);
 }
 
+.dialog-btn--confirm {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.dialog-btn--confirm:hover {
+  background: var(--accent-hover);
+}
+
 .sidebar-new-chat {
   width: 100%;
   padding: 10px 12px;
@@ -892,11 +904,11 @@ html {
 }
 
 .sidebar-conversation-item:hover {
-  background: var(--surface);
+  background: var(--surface-hover);
 }
 
 .sidebar-conversation-item--active {
-  background: var(--surface);
+  background: var(--surface-hover);
   outline: 1px solid var(--border);
 }
 
@@ -1055,7 +1067,7 @@ html {
   color: var(--danger, #e53e3e);
   padding: 8px 12px;
   text-align: center;
-  background: rgba(229, 62, 62, 0.1);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
   border-radius: 6px;
   margin: 4px 12px;
 }
@@ -1109,4 +1121,94 @@ html {
   background: var(--danger, #e53e3e);
   color: white;
   border-color: var(--danger, #e53e3e);
+}
+
+/* ── Composer Wrapper ── */
+
+.composer-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Pending Attachments (above composer) ── */
+
+.pending-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 24px 8px;
+}
+
+/* ── Attachment Chip ── */
+
+.attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-chip);
+  padding: 3px 10px;
+  white-space: nowrap;
+  cursor: default;
+}
+
+a.attachment-chip {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a.attachment-chip:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.attachment-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 1px;
+  margin-left: 2px;
+  border-radius: 4px;
+  line-height: 0;
+}
+
+.attachment-chip-remove:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+/* ── Message Attachments ── */
+
+.message-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 20px 4px 56px;
+}
+
+.attachment-image-link {
+  display: inline-block;
+  line-height: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  transition: opacity 0.15s;
+}
+
+.attachment-image-link:hover {
+  opacity: 0.85;
+}
+
+.attachment-image {
+  max-width: 240px;
+  max-height: 180px;
+  object-fit: cover;
+  display: block;
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { ApiThinkingResult, ConversationEntry, ConversationData, CreateConversationPayload, MessageData } from '../types';
+import type { ApiThinkingResult, AttachmentData, ConversationEntry, ConversationData, CreateConversationPayload, MessageData } from '../types';
 
 const API_BASE =
   import.meta.env.DEV ? 'http://localhost:8000' : '';
@@ -94,6 +94,29 @@ export const api = {
       throw new Error(msg);
     }
     return res.blob();
+  },
+
+  async uploadAttachment(file: File): Promise<AttachmentData> {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch(`${API_BASE}/api/attachments`, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || res.statusText;
+      throw new Error(msg);
+    }
+    return res.json();
+  },
+
+  async deleteAttachment(id: string): Promise<void> {
+    const res = await fetch(`${API_BASE}/api/attachments/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+    if (!res.ok && res.status !== 404) {
+      throw new Error('Failed to delete attachment');
+    }
   },
 
   // ── Conversations ──

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,12 @@
+export interface AttachmentData {
+  id: string;
+  filename: string;
+  mime_type: string;
+  size: number;
+  checksum: string;
+  created_at: string;
+}
+
 export interface ApiThinkingResult {
   response: string;
   thinking_summary: string[];


### PR DESCRIPTION
## Summary

Completes v0.3.0 by closing the attachment lifecycle:

### Phase 5 — Reference population
- `AttachmentStore.update_metadata()` for non-ownership references
- `POST/PUT /api/conversations` populates `conversation_id` / `message_id` in attachment metadata on persist

### Phase 6 — Cleanup
- `DELETE /api/conversations/<id>` cleans up attachments before deletion
- Idempotent: missing attachments → warning only
- Partial failures do not block conversation deletion

### Verification
- `check_attachments` covers full lifecycle: upload → persist → reload → delete → verify no orphans
- `python -m backend.verify attachments` reports ✓ for every step

### UI fixes
- `.dialog` now has `box-shadow` for elevation parity across themes
- `.dialog-btn--confirm` fixes invisible primary button caused by CSS specificity override

### Test results
- 468 backend tests (up from 457)
- 19 React tests
- 7/7 platform verify checks

## Verification policy compliance

```
alma verify --platform  → PASS (7/7)
ruff check              → PASS
ruff format --check     → PASS
pytest backend/tests/   → 468 passed
vitest run              → 19 passed
npm run build           → OK
```

## Checklist
- [x] attachment architecture frozen under ADR 0007
- [x] UI tokens frozen
- [x] no hard-coded colors outside exceptions
- [x] cleanup idempotent
- [x] `alma verify` covers full lifecycle