### PR TITLE
feat: native macOS client foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ coverage.xml
 # Build artifacts
 frontend/dist/
 
+# Swift
+swift/.build/
+
 # Verification artifacts
 backend/verify-output/
 

--- a/docs/architecture/0008-native-macos-client.md
+++ b/docs/architecture/0008-native-macos-client.md
@@ -1,0 +1,86 @@
+# ADR 0008: Native macOS Client
+
+**Date:** 2026-07-07
+**Status:** Accepted
+
+## Context
+
+Alma currently has a web UI (React) and a static HTML UI. Both are
+browser-based and share the same backend. As the product matures, a
+desktop-class experience becomes valuable — native window management,
+system-wide shortcuts, offline readiness, and deeper macOS integration
+(Quick Look, Share Sheet, Spotlight, Dock menu).
+
+The decision is not whether to build a desktop client, but what form it
+should take and how it relates to the existing architecture.
+
+## Decision
+
+### Maintain a native SwiftUI client alongside the web UI
+
+A native macOS app provides integration that a browser cannot:
+
+- **Window management** — native titlebar, tabs, spaces, full-screen
+- **System services** — drag-and-drop from Finder, Quick Look, Share Sheet
+- **Notifications** — native Notification Center delivery
+- **Menu bar** — global shortcuts and status without the browser open
+- **Offline resilience** — local-first data access without network dependency
+
+Electron or Tauri wrappers would inherit the browser's sandbox
+limitations while adding bundle size and complexity. SwiftUI gives a
+genuinely native feel with less code than AppKit.
+
+### Reuse the existing HTTP API instead of rewriting business logic
+
+The Python backend already implements:
+
+- Conversation CRUD and search
+- Message generation with thinking mode
+- Attachment upload, storage, and lifecycle
+- Anonymous identity management
+- Health and configuration endpoints
+
+The Swift client communicates with this backend over HTTP using
+URLSession. This means:
+
+- Feature work happens once in the backend
+- Both UIs (React and Swift) get new capabilities simultaneously
+- The verification suite covers both frontends with the same checks
+- No business logic duplication across languages
+
+Every API endpoint the web app uses is available to the Swift app. The
+Swift app adds native UI on top of the same data layer.
+
+### Ship a bundled local backend instead of reimplementing it in Swift
+
+The backend is mature, verified, and integrates with platform services
+(storage, mail, auth, notifications). Rewriting it in Swift would:
+
+- Duplicate thousands of lines of tested Python
+- Require parallel verification of two backend implementations
+- Create a second platform services integration to maintain
+- Lose the existing verification framework
+
+Instead, the macOS `.app` bundle includes a Python runtime and the
+existing backend. The app starts the backend on `localhost` at launch
+and stops it on quit. The Swift UI is a client of this local server.
+
+This keeps one backend, one verification system, and one truth:
+
+- **Web UI** → HTTP → **Backend**
+- **Swift UI** → HTTP → **Backend** (embedded or remote)
+
+## Consequences
+
+- The Swift app is a UI client, not a standalone application — it
+  requires the backend running locally or remotely.
+- Changes to API responses affect both frontends equally, which
+  encourages backward-compatible API design.
+- The bundled backend increases the app bundle size, but only by the
+  Python runtime and project code — no second implementation.
+- Verification extends naturally: the same scenarios run against both
+  UIs, confirming they consume the same API correctly.
+- Future macOS features (Spotlight indexing, Quick Look thumbnails) can
+  call backend endpoints or storage directly from Swift.
+- Platform services remain product-agnostic — the Swift app is just
+  another consumer of the same infrastructure.

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "Alma",
+    platforms: [
+        .macOS(.v15),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Alma",
+            resources: [
+                .process("Assets.xcassets"),
+            ]
+        ),
+        .testTarget(
+            name: "AlmaTests",
+            dependencies: ["Alma"]
+        ),
+    ]
+)

--- a/swift/Sources/Alma/App/AlmaApp.swift
+++ b/swift/Sources/Alma/App/AlmaApp.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+@main
+struct AlmaApp: App {
+    @State private var selectedTheme: AppTheme = .system
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.theme, selectedTheme)
+                .preferredColorScheme(selectedTheme.colorScheme)
+        }
+        .windowStyle(.titleBar)
+        .windowResizability(.contentSize)
+
+        Settings {
+            SettingsView(selectedTheme: $selectedTheme)
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        NavigationSplitView {
+            SidebarView()
+        } detail: {
+            ConversationView()
+        }
+    }
+}

--- a/swift/Sources/Alma/Assets.xcassets/Contents.json
+++ b/swift/Sources/Alma/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift/Sources/Alma/Core/API/APIClient.swift
+++ b/swift/Sources/Alma/Core/API/APIClient.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+public enum APIError: Error, LocalizedError, Equatable {
+    case invalidURL
+    case invalidResponse
+    case httpError(statusCode: Int, message: String)
+    case decodingFailed(Error)
+    case encodingFailed(Error)
+    case networkError(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .invalidResponse:
+            return "Invalid response"
+        case .httpError(let code, let message):
+            return "[\(code)] \(message)"
+        case .decodingFailed(let error):
+            return "Decoding failed: \(error.localizedDescription)"
+        case .encodingFailed(let error):
+            return "Encoding failed: \(error.localizedDescription)"
+        case .networkError(let error):
+            return error.localizedDescription
+        }
+    }
+
+    public static func == (lhs: APIError, rhs: APIError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidURL, .invalidURL): return true
+        case (.invalidResponse, .invalidResponse): return true
+        case (.httpError(let lc, let lm), .httpError(let rc, let rm)):
+            return lc == rc && lm == rm
+        case (.decodingFailed(let lE), .decodingFailed(let rE)):
+            return lE.localizedDescription == rE.localizedDescription
+        case (.encodingFailed(let lE), .encodingFailed(let rE)):
+            return lE.localizedDescription == rE.localizedDescription
+        case (.networkError(let lE), .networkError(let rE)):
+            return lE.localizedDescription == rE.localizedDescription
+        default:
+            return false
+        }
+    }
+}
+
+public final class APIClient: Sendable {
+    public let baseURL: URL
+    public let session: URLSession
+    public let decoder: JSONDecoder
+    public let encoder: JSONEncoder
+
+    public init(
+        baseURL: URL,
+        session: URLSession = .shared,
+        decoder: JSONDecoder? = nil,
+        encoder: JSONEncoder? = nil
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.decoder = decoder ?? {
+            let d = JSONDecoder()
+            d.keyDecodingStrategy = .convertFromSnakeCase
+            return d
+        }()
+        self.encoder = encoder ?? {
+            let e = JSONEncoder()
+            e.keyEncodingStrategy = .convertToSnakeCase
+            e.outputFormatting = [.sortedKeys]
+            return e
+        }()
+    }
+
+    public func buildRequest(
+        path: String,
+        method: String = "GET",
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil,
+        contentType: String? = "application/json"
+    ) throws -> URLRequest {
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: true)
+        else {
+            throw APIError.invalidURL
+        }
+        components.queryItems = queryItems
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        if let contentType {
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = body
+        return request
+    }
+
+    public func perform<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw APIError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        try validate(httpResponse, data: data)
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw APIError.decodingFailed(error)
+        }
+    }
+
+    public func performRaw(_ request: URLRequest) async throws -> Data {
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw APIError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        try validate(httpResponse, data: data)
+        return data
+    }
+
+    public func performWithoutBody(_ request: URLRequest) async throws {
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw APIError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        try validate(httpResponse, data: data)
+    }
+
+    // MARK: - Validation
+
+    private func validate(_ response: HTTPURLResponse, data: Data) throws {
+        let statusCode = response.statusCode
+        guard !(200...299).contains(statusCode) else { return }
+
+        let message = (
+            try? decoder.decode([String: String].self, from: data)
+        )?["error"] ?? "HTTP \(statusCode)"
+
+        throw APIError.httpError(statusCode: statusCode, message: message)
+    }
+
+    // MARK: - Convenience
+
+    public func get<T: Decodable>(
+        _ path: String,
+        queryItems: [URLQueryItem]? = nil
+    ) async throws -> T {
+        let request = try buildRequest(path: path, queryItems: queryItems)
+        return try await perform(request)
+    }
+
+    public func post<Body: Encodable, T: Decodable>(
+        _ path: String,
+        body: Body
+    ) async throws -> T {
+        let data = try encoder.encode(body)
+        let request = try buildRequest(path: path, method: "POST", body: data)
+        return try await perform(request)
+    }
+
+    public func put<Body: Encodable, T: Decodable>(
+        _ path: String,
+        body: Body
+    ) async throws -> T {
+        let data = try encoder.encode(body)
+        let request = try buildRequest(path: path, method: "PUT", body: data)
+        return try await perform(request)
+    }
+
+    public func delete(
+        _ path: String
+    ) async throws {
+        let request = try buildRequest(path: path, method: "DELETE")
+        try await performWithoutBody(request)
+    }
+
+    public func delete<T: Decodable>(
+        _ path: String
+    ) async throws -> T {
+        let request = try buildRequest(path: path, method: "DELETE")
+        return try await perform(request)
+    }
+}

--- a/swift/Sources/Alma/Core/API/AttachmentAPI.swift
+++ b/swift/Sources/Alma/Core/API/AttachmentAPI.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+final class MultipartFormData {
+    private let boundary: String
+    private var body: Data
+
+    init(boundary: String = "Boundary-\(UUID().uuidString)") {
+        self.boundary = boundary
+        self.body = Data()
+    }
+
+    func appendField(name: String, data: Data, filename: String? = nil, mimeType: String? = nil) {
+        body.append("--\(boundary)\r\n")
+
+        if let filename {
+            body.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        } else {
+            body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n")
+        }
+
+        if let mimeType {
+            body.append("Content-Type: \(mimeType)\r\n")
+        }
+
+        body.append("\r\n")
+        body.append(data)
+        body.append("\r\n")
+    }
+
+    func build() -> (Data, contentType: String) {
+        var finalBody = body
+        finalBody.append("--\(boundary)--\r\n")
+        return (finalBody, "multipart/form-data; boundary=\(boundary)")
+    }
+}
+
+extension Data {
+    mutating func append(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            append(data)
+        }
+    }
+}
+
+public final class AttachmentAPI: Sendable {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func upload(data: Data, filename: String, mimeType: String) async throws -> Attachment {
+        let form = MultipartFormData()
+        form.appendField(name: "file", data: data, filename: filename, mimeType: mimeType)
+        let (body, contentType) = form.build()
+
+        let request = try client.buildRequest(
+            path: "/api/attachments",
+            method: "POST",
+            body: body,
+            contentType: contentType
+        )
+        return try await client.perform(request)
+    }
+
+    public func download(id: String) async throws -> Data {
+        let request = try client.buildRequest(path: "/api/attachments/\(id)")
+        return try await client.performRaw(request)
+    }
+
+    public func getMetadata(id: String) async throws -> Attachment {
+        try await client.get("/api/attachments/\(id)/metadata")
+    }
+
+    public func delete(id: String) async throws {
+        try await client.delete("/api/attachments/\(id)")
+    }
+}

--- a/swift/Sources/Alma/Core/API/ConversationAPI.swift
+++ b/swift/Sources/Alma/Core/API/ConversationAPI.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public final class ConversationAPI: Sendable {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func list() async throws -> [ConversationIndexEntry] {
+        try await client.get("/api/conversations")
+    }
+
+    public func get(id: String) async throws -> Conversation {
+        try await client.get("/api/conversations/\(id)")
+    }
+
+    public func create(_ conversation: Conversation) async throws -> Conversation {
+        try await client.post("/api/conversations", body: conversation)
+    }
+
+    public func update(id: String, _ conversation: Conversation) async throws -> Conversation {
+        try await client.put("/api/conversations/\(id)", body: conversation)
+    }
+
+    public func delete(id: String) async throws {
+        try await client.delete("/api/conversations/\(id)")
+    }
+}

--- a/swift/Sources/Alma/Core/API/GenerationAPI.swift
+++ b/swift/Sources/Alma/Core/API/GenerationAPI.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+public struct GenerateRequest: Codable, Sendable {
+    public let prompt: String?
+    public let messages: [ChatMessage]?
+
+    public init(prompt: String? = nil, messages: [ChatMessage]? = nil) {
+        self.prompt = prompt
+        self.messages = messages
+    }
+}
+
+public final class GenerationAPI: Sendable {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func generate(prompt: String) async throws -> String {
+        let request = GenerateRequest(prompt: prompt)
+        let response: GenerationResponse = try await client.post("/api/generate", body: request)
+        return response.response
+    }
+
+    public func generate(messages: [ChatMessage]) async throws -> String {
+        let request = GenerateRequest(messages: messages)
+        let response: GenerationResponse = try await client.post("/api/generate", body: request)
+        return response.response
+    }
+
+    public func generateWithThinking(prompt: String) async throws -> ThinkingResponse {
+        let request = GenerateRequest(prompt: prompt)
+        return try await client.post("/api/generate-with-thinking", body: request)
+    }
+
+    public func generateWithThinking(messages: [ChatMessage]) async throws -> ThinkingResponse {
+        let request = GenerateRequest(messages: messages)
+        return try await client.post("/api/generate-with-thinking", body: request)
+    }
+
+    public func generateWithURLContext(prompt: String) async throws -> String {
+        let request = GenerateRequest(prompt: prompt)
+        let response: GenerationResponse = try await client.post("/api/generate-with-url-context", body: request)
+        return response.response
+    }
+
+    public func generateWithURLContext(messages: [ChatMessage]) async throws -> String {
+        let request = GenerateRequest(messages: messages)
+        let response: GenerationResponse = try await client.post("/api/generate-with-url-context", body: request)
+        return response.response
+    }
+}

--- a/swift/Sources/Alma/Core/API/HealthAPI.swift
+++ b/swift/Sources/Alma/Core/API/HealthAPI.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public final class HealthAPI: Sendable {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func health() async throws -> HealthResponse {
+        try await client.get("/api/health")
+    }
+}

--- a/swift/Sources/Alma/Core/API/Models.swift
+++ b/swift/Sources/Alma/Core/API/Models.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+public struct ConversationIndexEntry: Codable, Identifiable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let mode: String
+    public let createdAt: String
+    public let updatedAt: String
+}
+
+public struct Conversation: Codable, Identifiable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let mode: String
+    public let schemaVersion: Int
+    public let createdAt: String
+    public let updatedAt: String
+    public var messages: [ChatMessage]
+    public let titleIsManual: Bool?
+
+    public init(
+        id: String,
+        title: String,
+        mode: String,
+        schemaVersion: Int = 1,
+        createdAt: String,
+        updatedAt: String,
+        messages: [ChatMessage],
+        titleIsManual: Bool? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.mode = mode
+        self.schemaVersion = schemaVersion
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+        self.titleIsManual = titleIsManual
+    }
+}
+
+public struct ChatMessage: Codable, Identifiable, Equatable, Sendable {
+    public let id: String
+    public let role: String
+    public let timestamp: String
+    public let content: String
+    public let thinking: String?
+    public let image: String?
+
+    public init(
+        id: String,
+        role: String,
+        timestamp: String,
+        content: String,
+        thinking: String? = nil,
+        image: String? = nil
+    ) {
+        self.id = id
+        self.role = role
+        self.timestamp = timestamp
+        self.content = content
+        self.thinking = thinking
+        self.image = image
+    }
+}
+
+public struct Attachment: Codable, Identifiable, Equatable, Sendable {
+    public let id: String
+    public let filename: String
+    public let mimeType: String
+    public let size: Int
+    public let checksum: String
+    public let storageKey: String
+    public let createdAt: String
+}
+
+public struct GenerationResponse: Codable, Equatable, Sendable {
+    public let response: String
+}
+
+public struct ThinkingResponse: Codable, Equatable, Sendable {
+    public let response: String
+    public let thinkingSummary: [String]
+}
+
+public struct HealthResponse: Codable, Equatable, Sendable {
+    public let status: String
+}

--- a/swift/Sources/Alma/Core/Theme/ThemeManager.swift
+++ b/swift/Sources/Alma/Core/Theme/ThemeManager.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+enum AppTheme: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+    }
+}
+
+struct ThemeKey: EnvironmentKey {
+    static let defaultValue: AppTheme = .system
+}
+
+extension EnvironmentValues {
+    var theme: AppTheme {
+        get { self[ThemeKey.self] }
+        set { self[ThemeKey.self] = newValue }
+    }
+}

--- a/swift/Sources/Alma/Features/Composer/ComposerView.swift
+++ b/swift/Sources/Alma/Features/Composer/ComposerView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct ComposerView: View {
+    @Binding var text: String
+    let onSend: () -> Void
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            attachmentButton
+            textEditor
+            sendButton
+        }
+        .padding(12)
+        .background(.fill.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .padding()
+    }
+
+    private var attachmentButton: some View {
+        Button(action: {}) {
+            Image(systemName: "plus")
+                .font(.body)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var textEditor: some View {
+        TextField("Message Alma…", text: $text, axis: .vertical)
+            .textFieldStyle(.plain)
+            .lineLimit(1...6)
+    }
+
+    private var sendButton: some View {
+        Button(action: onSend) {
+            Image(systemName: "arrow.up.circle.fill")
+                .font(.title2)
+        }
+        .buttonStyle(.plain)
+        .disabled(text.trimmingCharacters(in: .whitespaces).isEmpty)
+        .keyboardShortcut(.return, modifiers: [])
+    }
+}

--- a/swift/Sources/Alma/Features/Conversation/ConversationView.swift
+++ b/swift/Sources/Alma/Features/Conversation/ConversationView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct ConversationView: View {
+    @State private var messages: [Message] = []
+    @State private var inputText = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            messageList
+            Divider()
+            composer
+        }
+    }
+
+    private var messageList: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(messages) { message in
+                    MessageBubble(message: message)
+                }
+            }
+            .padding()
+        }
+        .overlay {
+            if messages.isEmpty {
+                ContentUnavailableView(
+                    "Start a conversation",
+                    systemImage: "message",
+                    description: Text("Send a message to begin.")
+                )
+            }
+        }
+    }
+
+    private var composer: some View {
+        HStack(spacing: 8) {
+            TextField("Message Alma…", text: $inputText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...6)
+
+            if !inputText.trimmingCharacters(in: .whitespaces).isEmpty {
+                Button(action: sendMessage) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.return, modifiers: [])
+            }
+        }
+        .padding(12)
+        .background(.fill.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .padding()
+    }
+
+    private func sendMessage() {
+        guard !inputText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        let message = Message(
+            id: UUID().uuidString,
+            role: "user",
+            content: inputText.trimmingCharacters(in: .whitespaces)
+        )
+        messages.append(message)
+        inputText = ""
+    }
+}
+
+struct Message: Identifiable {
+    let id: String
+    let role: String
+    let content: String
+}
+
+struct MessageBubble: View {
+    let message: Message
+
+    var body: some View {
+        HStack {
+            if message.role == "user" {
+                Spacer()
+            }
+
+                    Group {
+                        if message.role == "user" {
+                            Text(message.content)
+                                .padding(12)
+                                .background(Color.accentColor)
+                                .foregroundStyle(.white)
+                        } else {
+                            Text(message.content)
+                                .padding(12)
+                                .background(.fill.tertiary)
+                                .foregroundStyle(.primary)
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            if message.role != "user" {
+                Spacer()
+            }
+        }
+    }
+}

--- a/swift/Sources/Alma/Features/Settings/SettingsView.swift
+++ b/swift/Sources/Alma/Features/Settings/SettingsView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Binding var selectedTheme: AppTheme
+
+    var body: some View {
+        TabView {
+            generalTab
+            appearanceTab
+            shortcutsTab
+        }
+        .scenePadding()
+        .frame(width: 450, height: 300)
+    }
+
+    private var generalTab: some View {
+        Form {
+            TextField("Server URL", text: .constant("http://localhost:5000"))
+                .textFieldStyle(.roundedBorder)
+        }
+        .formStyle(.grouped)
+        .tabItem {
+            Label("General", systemImage: "gearshape")
+        }
+    }
+
+    private var appearanceTab: some View {
+        Form {
+            Picker("Theme", selection: $selectedTheme) {
+                ForEach(AppTheme.allCases) { theme in
+                    Text(theme.displayName).tag(theme)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .tabItem {
+            Label("Appearance", systemImage: "paintbrush")
+        }
+    }
+
+    private var shortcutsTab: some View {
+        Form {
+            Text("Keyboard shortcuts will be configurable here.")
+                .foregroundStyle(.secondary)
+        }
+        .formStyle(.grouped)
+        .tabItem {
+            Label("Shortcuts", systemImage: "keyboard")
+        }
+    }
+}

--- a/swift/Sources/Alma/Features/Sidebar/SidebarView.swift
+++ b/swift/Sources/Alma/Features/Sidebar/SidebarView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct SidebarView: View {
+    @State private var conversations: [ConversationListItem] = []
+    @State private var searchText = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            newChatButton
+            searchBar
+            conversationList
+        }
+        .frame(minWidth: 240, maxWidth: 300)
+    }
+
+    private var newChatButton: some View {
+        Button(action: {}) {
+            Label("New conversation", systemImage: "plus")
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .padding(12)
+    }
+
+    private var searchBar: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search conversations…", text: $searchText)
+                .textFieldStyle(.plain)
+        }
+        .padding(8)
+        .background(.fill.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, 12)
+        .padding(.bottom, 8)
+    }
+
+    private var conversationList: some View {
+        List(conversations) { item in
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .lineLimit(1)
+                    .font(.body)
+                Text(item.preview)
+                    .lineLimit(1)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+        .listStyle(.plain)
+    }
+}
+
+struct ConversationListItem: Identifiable {
+    let id: String
+    let title: String
+    let preview: String
+}

--- a/swift/Tests/AlmaTests/APIClientTests.swift
+++ b/swift/Tests/AlmaTests/APIClientTests.swift
@@ -1,0 +1,329 @@
+import Testing
+import Foundation
+@testable import Alma
+
+final class MockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            fatalError("No mock handler set")
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+func makeClient() -> APIClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+    return APIClient(baseURL: URL(string: "http://localhost:8080")!, session: session)
+}
+
+@Suite(.serialized) struct NetworkingTests {
+
+    // MARK: - APIClient
+
+    @Test("GET request decodes response")
+    func testGet() async throws {
+        try await withMock(json: """
+        {"id":"1","title":"Test","mode":"chat","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+        """) {
+            let entry: ConversationIndexEntry = try await makeClient().get("/api/conversations")
+            #expect(entry.id == "1")
+            #expect(entry.title == "Test")
+        }
+    }
+
+    @Test("POST request encodes body and decodes response")
+    func testPost() async throws {
+        let msg = ChatMessage(id: "m1", role: "user", timestamp: "2025-01-01T00:00:00Z", content: "Hello")
+        let conversation = Conversation(
+            id: "1", title: "New Chat", mode: "chat",
+            createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
+            messages: [msg]
+        )
+        try await withMock(json: """
+        {"id":"1","title":"New Chat","mode":"chat","schema_version":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","messages":[{"id":"m1","role":"user","timestamp":"2025-01-01T00:00:00Z","content":"Hello"}]}
+        """, statusCode: 201) {
+            let created: Conversation = try await makeClient().post("/api/conversations", body: conversation)
+            #expect(created.id == "1")
+            #expect(created.messages.count == 1)
+            #expect(created.messages[0].content == "Hello")
+        }
+    }
+
+    @Test("PUT request encodes body and decodes response")
+    func testPut() async throws {
+        let msg = ChatMessage(id: "m1", role: "user", timestamp: "2025-01-01T00:00:00Z", content: "Updated")
+        let conversation = Conversation(
+            id: "1", title: "Updated Chat", mode: "chat",
+            createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
+            messages: [msg]
+        )
+        try await withMock(json: """
+        {"id":"1","title":"Updated Chat","mode":"chat","schema_version":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","messages":[{"id":"m1","role":"user","timestamp":"2025-01-01T00:00:00Z","content":"Updated"}]}
+        """) {
+            let updated: Conversation = try await makeClient().put("/api/conversations/1", body: conversation)
+            #expect(updated.title == "Updated Chat")
+            #expect(updated.messages[0].content == "Updated")
+        }
+    }
+
+    @Test("DELETE request returns no content")
+    func testDeleteNoContent() async throws {
+        try await withMock(data: Data(), statusCode: 204) {
+            let client = makeClient()
+            let request = try client.buildRequest(path: "/api/conversations/1", method: "DELETE")
+            try await client.performWithoutBody(request)
+        }
+    }
+
+    @Test("HTTP 404 throws not found error")
+    func testNotFound() async throws {
+        try await withMock(json: """
+        {"error":"Conversation not found"}
+        """, statusCode: 404) {
+            do {
+                let _: Conversation = try await makeClient().get("/api/conversations/nonexistent")
+                #expect(Bool(false), "Expected error to be thrown")
+            } catch APIError.httpError(let code, let message) {
+                #expect(code == 404)
+                #expect(message == "Conversation not found")
+            }
+        }
+    }
+
+    @Test("HTTP 500 throws server error")
+    func testServerError() async throws {
+        try await withMock(json: """
+        {"error":"Internal server error"}
+        """, statusCode: 500) {
+            do {
+                let _: [ConversationIndexEntry] = try await makeClient().get("/api/conversations")
+                #expect(Bool(false), "Expected error to be thrown")
+            } catch APIError.httpError(let code, let message) {
+                #expect(code == 500)
+                #expect(message == "Internal server error")
+            }
+        }
+    }
+
+    // MARK: - ConversationAPI
+
+    @Test("list returns conversation index entries")
+    func testConversationList() async throws {
+        try await withMock(json: """
+        [{"id":"1","title":"Chat 1","mode":"chat","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"},{"id":"2","title":"Chat 2","mode":"chat","created_at":"2025-01-02T00:00:00Z","updated_at":"2025-01-02T00:00:00Z"}]
+        """) {
+            let api = ConversationAPI(client: makeClient())
+            let entries = try await api.list()
+            #expect(entries.count == 2)
+            #expect(entries[0].title == "Chat 1")
+            #expect(entries[1].id == "2")
+        }
+    }
+
+    @Test("get returns single conversation")
+    func testConversationGet() async throws {
+        try await withMock(json: """
+        {"id":"1","title":"Chat 1","mode":"chat","schema_version":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","messages":[{"id":"m1","role":"user","timestamp":"2025-01-01T00:00:00Z","content":"Hello"}]}
+        """) {
+            let api = ConversationAPI(client: makeClient())
+            let conv = try await api.get(id: "1")
+            #expect(conv.title == "Chat 1")
+            #expect(conv.messages.count == 1)
+        }
+    }
+
+    @Test("create returns created conversation")
+    func testConversationCreate() async throws {
+        try await withMock(json: """
+        {"id":"new-id","title":"New Chat","mode":"chat","schema_version":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","messages":[]}
+        """, statusCode: 201) {
+            let api = ConversationAPI(client: makeClient())
+            let conv = Conversation(
+                id: "new-id", title: "New Chat", mode: "chat",
+                createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
+                messages: []
+            )
+            let created = try await api.create(conv)
+            #expect(created.id == "new-id")
+        }
+    }
+
+    @Test("conversation delete removes conversation")
+    func testConversationDelete() async throws {
+        try await withMock(data: Data(), statusCode: 204) {
+            let api = ConversationAPI(client: makeClient())
+            try await api.delete(id: "1")
+        }
+    }
+
+    // MARK: - GenerationAPI
+
+    @Test("generate with prompt returns response")
+    func testGeneratePrompt() async throws {
+        try await withMock(json: """
+        {"response":"Hello! How can I help you?"}
+        """) {
+            let api = GenerationAPI(client: makeClient())
+            let result = try await api.generate(prompt: "Hi")
+            #expect(result == "Hello! How can I help you?")
+        }
+    }
+
+    @Test("generate with messages returns response")
+    func testGenerateMessages() async throws {
+        try await withMock(json: """
+        {"response":"I remember our conversation."}
+        """) {
+            let api = GenerationAPI(client: makeClient())
+            let messages = [ChatMessage(id: "1", role: "user", timestamp: "", content: "Do you remember?")]
+            let result = try await api.generate(messages: messages)
+            #expect(result == "I remember our conversation.")
+        }
+    }
+
+    @Test("generate with thinking returns response and thinking summary")
+    func testGenerateWithThinking() async throws {
+        try await withMock(json: """
+        {"response":"Here is my answer.","thinking_summary":["Step 1: thinking","Step 2: more thinking"]}
+        """) {
+            let api = GenerationAPI(client: makeClient())
+            let result = try await api.generateWithThinking(prompt: "Think about this")
+            #expect(result.response == "Here is my answer.")
+            #expect(result.thinkingSummary.count == 2)
+            #expect(result.thinkingSummary[0] == "Step 1: thinking")
+        }
+    }
+
+    @Test("generate with URL context returns response")
+    func testGenerateWithURLContext() async throws {
+        try await withMock(json: """
+        {"response":"Based on the URL content..."}
+        """) {
+            let api = GenerationAPI(client: makeClient())
+            let result = try await api.generateWithURLContext(prompt: "Summarize this URL")
+            #expect(result == "Based on the URL content...")
+        }
+    }
+
+    // MARK: - AttachmentAPI
+
+    @Test("upload returns attachment metadata")
+    func testUpload() async throws {
+        try await withMock(json: """
+        {"id":"att-1","filename":"photo.png","mime_type":"image/png","size":1234,"checksum":"abc123","storage_key":"attachments/att-1.bin","created_at":"2025-01-01T00:00:00Z"}
+        """, statusCode: 201) {
+            let api = AttachmentAPI(client: makeClient())
+            let attachment = try await api.upload(
+                data: Data("fake-png".utf8),
+                filename: "photo.png",
+                mimeType: "image/png"
+            )
+            #expect(attachment.id == "att-1")
+            #expect(attachment.filename == "photo.png")
+            #expect(attachment.mimeType == "image/png")
+            #expect(attachment.size == 1234)
+        }
+    }
+
+    @Test("download returns raw data")
+    func testDownload() async throws {
+        let imageData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        try await withMock(data: imageData) {
+            let api = AttachmentAPI(client: makeClient())
+            let data = try await api.download(id: "att-1")
+            #expect(data == imageData)
+        }
+    }
+
+    @Test("get metadata returns attachment info")
+    func testGetMetadata() async throws {
+        try await withMock(json: """
+        {"id":"att-1","filename":"doc.pdf","mime_type":"application/pdf","size":5000,"checksum":"def456","storage_key":"attachments/att-1.bin","created_at":"2025-01-01T00:00:00Z"}
+        """) {
+            let api = AttachmentAPI(client: makeClient())
+            let metadata = try await api.getMetadata(id: "att-1")
+            #expect(metadata.filename == "doc.pdf")
+            #expect(metadata.mimeType == "application/pdf")
+        }
+    }
+
+    @Test("attachment delete removes attachment")
+    func testAttachmentDelete() async throws {
+        try await withMock(data: Data(), statusCode: 204) {
+            let api = AttachmentAPI(client: makeClient())
+            try await api.delete(id: "att-1")
+        }
+    }
+
+    // MARK: - HealthAPI
+
+    @Test("health returns status")
+    func testHealth() async throws {
+        try await withMock(json: """
+        {"status":"ok"}
+        """) {
+            let api = HealthAPI(client: makeClient())
+            let health = try await api.health()
+            #expect(health.status == "ok")
+        }
+    }
+
+    @Test("health returns degraded status")
+    func testDegraded() async throws {
+        try await withMock(json: """
+        {"status":"degraded"}
+        """) {
+            let api = HealthAPI(client: makeClient())
+            let health = try await api.health()
+            #expect(health.status == "degraded")
+        }
+    }
+}
+
+// MARK: - Helpers
+
+func withMock<T>(
+    json: String,
+    statusCode: Int = 200,
+    operation: () async throws -> T
+) async throws -> T {
+    try await withMock(
+        data: Data(json.utf8),
+        statusCode: statusCode,
+        operation: operation
+    )
+}
+
+func withMock<T>(
+    data: Data,
+    statusCode: Int = 200,
+    operation: () async throws -> T
+) async throws -> T {
+    MockURLProtocol.requestHandler = { request in
+        let response = try #require(HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        ))
+        return (response, data)
+    }
+    defer { MockURLProtocol.requestHandler = nil }
+    return try await operation()
+}

--- a/swift/Tests/AlmaTests/AlmaTests.swift
+++ b/swift/Tests/AlmaTests/AlmaTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import Alma
+
+struct AlmaTests {
+    @Test("App launches with default theme system")
+    func defaultTheme() {
+        let theme = AppTheme.system
+        #expect(theme.colorScheme == nil)
+        #expect(theme.displayName == "System")
+    }
+
+    @Test("Theme cases are unique")
+    func themeUniqueness() {
+        let cases = AppTheme.allCases.map(\.rawValue)
+        #expect(Set(cases).count == cases.count)
+    }
+
+    @Test("Light theme produces light color scheme")
+    func lightTheme() {
+        #expect(AppTheme.light.colorScheme == .light)
+    }
+
+    @Test("Dark theme produces dark color scheme")
+    func darkTheme() {
+        #expect(AppTheme.dark.colorScheme == .dark)
+    }
+}


### PR DESCRIPTION
Summary

Adds the foundation for the native macOS client.

Included

* ADR 0008 describing the native client architecture
* Swift package and project scaffold
* Shared networking foundation
* Conversation, generation, attachment, and health API clients
* Networking unit tests

Not included

* Backend changes
* Business logic
* Local persistence
* UI integration with networking

This establishes the networking layer for the Swift client while continuing to use the existing HTTP API.