### PR TITLE
feat: wire SwiftUI views to ConversationAPI via ConversationService

### DIFF
--- a/swift/Sources/Alma/App/AlmaApp.swift
+++ b/swift/Sources/Alma/App/AlmaApp.swift
@@ -3,10 +3,15 @@ import SwiftUI
 @main
 struct AlmaApp: App {
     @State private var selectedTheme: AppTheme = .system
+    @State private var service = ConversationService(
+        api: ConversationAPI(
+            client: APIClient(baseURL: URL(string: "http://localhost:8080")!)
+        )
+    )
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(service: service)
                 .environment(\.theme, selectedTheme)
                 .preferredColorScheme(selectedTheme.colorScheme)
         }
@@ -20,11 +25,16 @@ struct AlmaApp: App {
 }
 
 struct ContentView: View {
+    let service: ConversationService
+
     var body: some View {
         NavigationSplitView {
-            SidebarView()
+            SidebarView(service: service)
         } detail: {
-            ConversationView()
+            ConversationView(service: service)
+        }
+        .task {
+            await service.loadConversations()
         }
     }
 }

--- a/swift/Sources/Alma/Core/API/Models.swift
+++ b/swift/Sources/Alma/Core/API/Models.swift
@@ -13,8 +13,8 @@ public struct Conversation: Codable, Identifiable, Equatable, Sendable {
     public let title: String
     public let mode: String
     public let schemaVersion: Int
-    public let createdAt: String
-    public let updatedAt: String
+    public let createdAt: String?
+    public let updatedAt: String?
     public var messages: [ChatMessage]
     public let titleIsManual: Bool?
 
@@ -23,8 +23,8 @@ public struct Conversation: Codable, Identifiable, Equatable, Sendable {
         title: String,
         mode: String,
         schemaVersion: Int = 1,
-        createdAt: String,
-        updatedAt: String,
+        createdAt: String? = nil,
+        updatedAt: String? = nil,
         messages: [ChatMessage],
         titleIsManual: Bool? = nil
     ) {

--- a/swift/Sources/Alma/Core/ConversationService.swift
+++ b/swift/Sources/Alma/Core/ConversationService.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+public final class ConversationService {
+    public var conversations: [ConversationIndexEntry] = []
+    public var selectedConversation: Conversation? = nil
+    public var selectedId: String? = nil
+    public var isLoading = false
+    public var error: String? = nil
+
+    private let api: ConversationAPI
+    private let defaults: UserDefaults
+
+    public init(api: ConversationAPI, defaults: UserDefaults = .standard) {
+        self.api = api
+        self.defaults = defaults
+    }
+
+    private var savedConversationId: String? {
+        get { defaults.string(forKey: selectedIdKey) }
+        set { defaults.set(newValue, forKey: selectedIdKey) }
+    }
+
+    public func loadConversations() async {
+        isLoading = true
+        error = nil
+        do {
+            conversations = try await api.list()
+            let savedId = savedConversationId
+            if let savedId,
+               conversations.contains(where: { $0.id == savedId })
+            {
+                selectedId = savedId
+                await selectConversation(savedId)
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    public func selectConversation(_ id: String) async {
+        savedConversationId = id
+        selectedId = id
+        isLoading = true
+        error = nil
+        do {
+            selectedConversation = try await api.get(id: id)
+        } catch {
+            savedConversationId = nil
+            selectedId = nil
+            selectedConversation = nil
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    public func createConversation() async {
+        isLoading = true
+        error = nil
+        do {
+            let conv = Conversation(
+                id: "",
+                title: "",
+                mode: "chat",
+                messages: []
+            )
+            let created = try await api.create(conv)
+            let entry = ConversationIndexEntry(
+                id: created.id,
+                title: created.title,
+                mode: created.mode,
+                createdAt: created.createdAt ?? "",
+                updatedAt: created.updatedAt ?? ""
+            )
+            conversations.insert(entry, at: 0)
+            selectedConversation = created
+            selectedId = created.id
+            savedConversationId = created.id
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+}
+
+private let selectedIdKey = "selectedConversationId"

--- a/swift/Sources/Alma/Features/Conversation/ConversationView.swift
+++ b/swift/Sources/Alma/Features/Conversation/ConversationView.swift
@@ -1,28 +1,31 @@
 import SwiftUI
 
 struct ConversationView: View {
-    @State private var messages: [Message] = []
-    @State private var inputText = ""
+    let service: ConversationService
 
     var body: some View {
-        VStack(spacing: 0) {
-            messageList
-            Divider()
-            composer
+        if let conversation = service.selectedConversation {
+            messageList(conversation)
+        } else {
+            ContentUnavailableView(
+                "Select a conversation",
+                systemImage: "sidebar.left",
+                description: Text("Choose a conversation from the sidebar.")
+            )
         }
     }
 
-    private var messageList: some View {
+    private func messageList(_ conversation: Conversation) -> some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                ForEach(messages) { message in
+                ForEach(conversation.messages) { message in
                     MessageBubble(message: message)
                 }
             }
             .padding()
         }
         .overlay {
-            if messages.isEmpty {
+            if conversation.messages.isEmpty {
                 ContentUnavailableView(
                     "Start a conversation",
                     systemImage: "message",
@@ -31,48 +34,10 @@ struct ConversationView: View {
             }
         }
     }
-
-    private var composer: some View {
-        HStack(spacing: 8) {
-            TextField("Message Alma…", text: $inputText, axis: .vertical)
-                .textFieldStyle(.plain)
-                .lineLimit(1...6)
-
-            if !inputText.trimmingCharacters(in: .whitespaces).isEmpty {
-                Button(action: sendMessage) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.title2)
-                }
-                .buttonStyle(.plain)
-                .keyboardShortcut(.return, modifiers: [])
-            }
-        }
-        .padding(12)
-        .background(.fill.quaternary)
-        .clipShape(RoundedRectangle(cornerRadius: 18))
-        .padding()
-    }
-
-    private func sendMessage() {
-        guard !inputText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-        let message = Message(
-            id: UUID().uuidString,
-            role: "user",
-            content: inputText.trimmingCharacters(in: .whitespaces)
-        )
-        messages.append(message)
-        inputText = ""
-    }
-}
-
-struct Message: Identifiable {
-    let id: String
-    let role: String
-    let content: String
 }
 
 struct MessageBubble: View {
-    let message: Message
+    let message: ChatMessage
 
     var body: some View {
         HStack {
@@ -80,20 +45,20 @@ struct MessageBubble: View {
                 Spacer()
             }
 
-                    Group {
-                        if message.role == "user" {
-                            Text(message.content)
-                                .padding(12)
-                                .background(Color.accentColor)
-                                .foregroundStyle(.white)
-                        } else {
-                            Text(message.content)
-                                .padding(12)
-                                .background(.fill.tertiary)
-                                .foregroundStyle(.primary)
-                        }
-                    }
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            Group {
+                if message.role == "user" {
+                    Text(message.content)
+                        .padding(12)
+                        .background(Color.accentColor)
+                        .foregroundStyle(.white)
+                } else {
+                    Text(message.content)
+                        .padding(12)
+                        .background(.fill.tertiary)
+                        .foregroundStyle(.primary)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
 
             if message.role != "user" {
                 Spacer()

--- a/swift/Sources/Alma/Features/Sidebar/SidebarView.swift
+++ b/swift/Sources/Alma/Features/Sidebar/SidebarView.swift
@@ -1,20 +1,59 @@
 import SwiftUI
 
 struct SidebarView: View {
-    @State private var conversations: [ConversationListItem] = []
+    @Bindable var service: ConversationService
     @State private var searchText = ""
 
     var body: some View {
         VStack(spacing: 0) {
             newChatButton
             searchBar
-            conversationList
+            content
         }
         .frame(minWidth: 240, maxWidth: 300)
     }
 
+    @ViewBuilder
+    private var content: some View {
+        if service.isLoading && service.conversations.isEmpty {
+            loadingView
+        } else if let error = service.error, service.conversations.isEmpty {
+            errorView(error)
+        } else if service.conversations.isEmpty {
+            emptyView
+        } else {
+            conversationList
+        }
+    }
+
+    private var loadingView: some View {
+        Spacer()
+    }
+
+    private var emptyView: some View {
+        ContentUnavailableView(
+            "No conversations",
+            systemImage: "message",
+            description: Text("Start a new conversation.")
+        )
+    }
+
+    private func errorView(_ error: String) -> some View {
+        ContentUnavailableView {
+            Label("Could not load", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(error)
+        } actions: {
+            Button("Retry") {
+                Task { await service.loadConversations() }
+            }
+        }
+    }
+
     private var newChatButton: some View {
-        Button(action: {}) {
+        Button(action: {
+            Task { await service.createConversation() }
+        }) {
             Label("New conversation", systemImage: "plus")
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -37,24 +76,21 @@ struct SidebarView: View {
     }
 
     private var conversationList: some View {
-        List(conversations) { item in
-            VStack(alignment: .leading, spacing: 2) {
-                Text(item.title)
-                    .lineLimit(1)
-                    .font(.body)
-                Text(item.preview)
-                    .lineLimit(1)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        List(selection: $service.selectedId) {
+            ForEach(service.conversations) { item in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title)
+                        .lineLimit(1)
+                        .font(.body)
+                }
+                .padding(.vertical, 4)
+                .tag(item.id as String?)
             }
-            .padding(.vertical, 4)
         }
         .listStyle(.plain)
+        .onChange(of: service.selectedId) { _, newId in
+            guard let id = newId else { return }
+            Task { await service.selectConversation(id) }
+        }
     }
-}
-
-struct ConversationListItem: Identifiable {
-    let id: String
-    let title: String
-    let preview: String
 }

--- a/swift/Tests/AlmaTests/APIClientTests.swift
+++ b/swift/Tests/AlmaTests/APIClientTests.swift
@@ -298,6 +298,7 @@ func makeClient() -> APIClient {
 
 // MARK: - Helpers
 
+@MainActor
 func withMock<T>(
     json: String,
     statusCode: Int = 200,
@@ -310,6 +311,7 @@ func withMock<T>(
     )
 }
 
+@MainActor
 func withMock<T>(
     data: Data,
     statusCode: Int = 200,

--- a/swift/Tests/AlmaTests/ConversationServiceTests.swift
+++ b/swift/Tests/AlmaTests/ConversationServiceTests.swift
@@ -1,0 +1,154 @@
+import Testing
+import Foundation
+@testable import Alma
+
+@MainActor
+extension NetworkingTests {
+
+    @Test("list conversations populates conversations array")
+    func testServiceListConversations() async throws {
+        try await withMock(json: """
+        [{"id":"1","title":"Chat 1","mode":"chat","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}]
+        """) {
+            let service = ConversationService(api: ConversationAPI(client: makeClient()))
+            await service.loadConversations()
+            #expect(service.conversations.count == 1)
+            #expect(service.conversations[0].title == "Chat 1")
+            #expect(service.isLoading == false)
+            #expect(service.error == nil)
+        }
+    }
+
+    @Test("empty list shows no conversations")
+    func testServiceEmptyList() async throws {
+        try await withMock(json: "[]") {
+            let service = ConversationService(api: ConversationAPI(client: makeClient()))
+            await service.loadConversations()
+            #expect(service.conversations.isEmpty)
+            #expect(service.selectedConversation == nil)
+        }
+    }
+
+    @Test("load conversation populates selected conversation")
+    func testServiceLoadConversation() async throws {
+        try await withMock(json: """
+        {"id":"1","title":"Chat 1","mode":"chat","schema_version":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","messages":[{"id":"m1","role":"user","timestamp":"2025-01-01T00:00:00Z","content":"Hello"}]}
+        """) {
+            let service = ConversationService(api: ConversationAPI(client: makeClient()))
+            await service.selectConversation("1")
+            #expect(service.selectedConversation != nil)
+            #expect(service.selectedConversation?.title == "Chat 1")
+            #expect(service.selectedConversation?.messages.count == 1)
+            #expect(service.selectedId == "1")
+        }
+    }
+
+    @Test("create conversation adds to list and selects it")
+    func testServiceCreateConversation() async throws {
+        let responseJSON = """
+        {"id":"new-id","title":"New Chat","mode":"chat","schema_version":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","messages":[]}
+        """
+        try await withMock(json: responseJSON, statusCode: 201) {
+            let service = ConversationService(api: ConversationAPI(client: makeClient()))
+            await service.createConversation()
+            #expect(service.conversations.count == 1)
+            #expect(service.conversations[0].id == "new-id")
+            #expect(service.selectedConversation?.id == "new-id")
+            #expect(service.selectedId == "new-id")
+        }
+    }
+
+    @Test("restore loads saved conversation on launch")
+    func testServiceRestoreConversation() async throws {
+        let savedId = "saved-1"
+        let defaults = UserDefaults(suiteName: "test-restore-\(UUID().uuidString)")!
+        defaults.set(savedId, forKey: "selectedConversationId")
+
+        let listJSON = """
+        [{"id":"saved-1","title":"Saved Chat","mode":"chat","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}]
+        """
+        let convJSON = """
+        {"id":"saved-1","title":"Saved Chat","mode":"chat","schema_version":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","messages":[{"id":"m1","role":"user","timestamp":"2025-01-01T00:00:00Z","content":"Hello"}]}
+        """
+
+        var callCount = 0
+        try await withMock(data: Data(), statusCode: 200) {
+            MockURLProtocol.requestHandler = { request in
+                callCount += 1
+                if callCount == 1 {
+                    let data = Data(listJSON.utf8)
+                    let response = try #require(HTTPURLResponse(
+                        url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+                        headerFields: ["Content-Type": "application/json"]
+                    ))
+                    return (response, data)
+                }
+                let data = Data(convJSON.utf8)
+                let response = try #require(HTTPURLResponse(
+                    url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "application/json"]
+                ))
+                return (response, data)
+            }
+            defer { MockURLProtocol.requestHandler = nil }
+
+            let service = ConversationService(
+                api: ConversationAPI(client: makeClient()),
+                defaults: defaults
+            )
+            await service.loadConversations()
+            #expect(service.selectedConversation?.id == "saved-1")
+            #expect(service.selectedConversation?.title == "Saved Chat")
+            #expect(service.selectedId == "saved-1")
+            #expect(callCount == 2)
+        }
+    }
+
+    @Test("restore falls back gracefully when saved conversation is gone")
+    func testServiceRestoreFallback() async throws {
+        let savedId = "deleted-id"
+        let defaults = UserDefaults(suiteName: "test-fallback-\(UUID().uuidString)")!
+        defaults.set(savedId, forKey: "selectedConversationId")
+
+        let listJSON = """
+        [{"id":"other-1","title":"Other Chat","mode":"chat","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}]
+        """
+
+        try await withMock(json: listJSON) {
+            let service = ConversationService(
+                api: ConversationAPI(client: makeClient()),
+                defaults: defaults
+            )
+            await service.loadConversations()
+            #expect(service.conversations.count == 1)
+            #expect(service.selectedConversation == nil)
+            #expect(service.selectedId == nil)
+        }
+    }
+
+    @Test("API failure sets error and clears state")
+    func testServiceError() async throws {
+        try await withMock(json: """
+        {"error":"Internal server error"}
+        """, statusCode: 500) {
+            let service = ConversationService(api: ConversationAPI(client: makeClient()))
+            await service.loadConversations()
+            #expect(service.error != nil)
+            #expect(service.conversations.isEmpty)
+            #expect(service.isLoading == false)
+        }
+    }
+
+    @Test("selecting nonexistent conversation clears selection")
+    func testServiceSelectNotFound() async throws {
+        try await withMock(json: """
+        {"error":"Conversation not found"}
+        """, statusCode: 404) {
+            let service = ConversationService(api: ConversationAPI(client: makeClient()))
+            await service.selectConversation("nonexistent")
+            #expect(service.selectedConversation == nil)
+            #expect(service.selectedId == nil)
+            #expect(service.error != nil)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wire the SwiftUI interface to live API data through a new `ConversationService` layer.

## Changes

- **ConversationService** (`@MainActor @Observable`) — manages conversation list, selection, creation, and UserDefaults persistence
- **Conversation model** — `createdAt`/`updatedAt` made optional for create requests (server auto-generates)
- **SidebarView** — shows loading/empty/error/retry states; search bar preserved; new chat triggers `ConversationService.createConversation()`
- **ConversationView** — displays real `ChatMessage` objects from the API; composer removed (out of scope)
- **ConversationServiceTests** — 8 tests covering list, empty, load, create, restore, fallback, error, and not-found scenarios
- **withMock helper** — adapted for `@MainActor` test closures (all 32 tests pass)

## Verification

- `swift build` — clean
- `swift test` — 32/32 passed
- `ruff check` — all checks passed
- `ruff format --check` — 91 files already formatted
- No changes outside `swift/`