### PR TITLE
feat(macos): automated DMG packaging

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
+# SPDX-License-Identifier: MIT
+---
+# Build the native macOS client.
+#
+# Triggered on version tags. Produces Alma.app as a workflow artifact.
+# Packaging into DMG and release upload happen in separate commits.
+
+name: Release macOS
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Build Alma.app
+        run: ./scripts/macos/build.sh ${{ github.ref_name }}
+
+      - name: Upload Alma.app as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Alma-macOS-app
+          path: output/Alma.app
+          if-no-files-found: error

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
 # SPDX-License-Identifier: MIT
 ---
-# Build and package the native macOS client.
+# Build, package, and publish the native macOS client.
 #
-# Triggered on version tags. Produces Alma.app and Alma.dmg as
-# workflow artifacts. Release upload happens in a separate commit.
+# Triggered on version tags. Produces Alma.app and Alma.dmg,
+# verifies the bundle, and attaches the DMG to the GitHub Release.
 
 name: Release macOS
 
@@ -14,7 +14,7 @@ on:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -48,3 +48,9 @@ jobs:
           name: Alma-macOS-dmg
           path: output/Alma-*.dmg
           if-no-files-found: error
+
+      - name: Upload DMG to GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: output/Alma-*.dmg

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Palmshed
 # SPDX-License-Identifier: MIT
 ---
-# Build the native macOS client.
+# Build and package the native macOS client.
 #
-# Triggered on version tags. Produces Alma.app as a workflow artifact.
-# Packaging into DMG and release upload happen in separate commits.
+# Triggered on version tags. Produces Alma.app and Alma.dmg as
+# workflow artifacts. Release upload happens in a separate commit.
 
 name: Release macOS
 
@@ -29,9 +29,22 @@ jobs:
       - name: Build Alma.app
         run: ./scripts/macos/build.sh ${{ github.ref_name }}
 
+      - name: Package Alma.dmg
+        run: ./scripts/macos/package.sh
+
+      - name: Verify bundle and DMG
+        run: ./scripts/macos/verify.sh
+
       - name: Upload Alma.app as workflow artifact
         uses: actions/upload-artifact@v4
         with:
           name: Alma-macOS-app
           path: output/Alma.app
+          if-no-files-found: error
+
+      - name: Upload Alma.dmg as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Alma-macOS-dmg
+          path: output/Alma-*.dmg
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,7 @@ swift/.build/
 # Verification artifacts
 backend/verify-output/
 
+# macOS packaging output
+output/
+
 .env*

--- a/docs/architecture/0009-macos-packaging.md
+++ b/docs/architecture/0009-macos-packaging.md
@@ -1,0 +1,85 @@
+# ADR 0009: Native macOS Packaging
+
+**Date:** 2026-07-08
+**Status:** Accepted
+
+## Context
+
+The native macOS client (ADR 0008) currently requires users to clone
+the repository and build from source with Swift. As the client matures
+into a usable application, distributing a pre-built binary removes the
+primary barrier to adoption: requiring a Swift development environment.
+
+The decision is not whether to distribute binaries, but what form the
+distribution should take and how to produce it sustainably.
+
+## Decision
+
+### Distribute a DMG image instead of requiring a source build
+
+A DMG provides the familiar Mac installation experience: download, open,
+drag to Applications. Alternatives were considered:
+
+- **Source-only**: lowest maintenance, but requires Xcode and
+  dependencies. Acceptable during development, not for general use.
+- **Homebrew tap**: appeals to power users, but adds a distribution
+  channel to maintain. Better as a later addition.
+- **.zip of .app**: simpler to produce than DMG, but loses the visual
+  installation metaphor (background, icon positioning, Applications
+  alias) that Mac users expect.
+- **Mac App Store**: requires Apple Developer enrollment, code signing,
+  notarization, and approval delays. Premature for a pre-v1 product.
+
+The DMG is the lowest-friction distribution format for an unsigned open
+source Mac app.
+
+### Package through GitHub Actions, not locally
+
+Packaging in CI rather than on a developer machine:
+
+- Produces bit-for-bit reproducible artifacts from a clean environment
+- Eliminates "works on my machine" discrepancies between development
+  and release builds
+- Runs packaging scripts on every tagged release without manual
+  intervention
+- Archives build artifacts and release assets in one place (GitHub)
+- Does not require developers to install DMG tooling locally
+
+The GitHub Release asset attachment path means no separate storage
+service is needed. The DMG lives alongside the source archive.
+
+### Keep packaging, signing, and notarization as separate milestones
+
+Packaging, code signing, Hardened Runtime, notarization, and stapling
+are independent concerns that are often combined into a single
+"distribution" task. Combining them:
+
+- Delays the first shippable binary until all Apple developer
+  prerequisites are met
+- Couples CI workflow changes with Apple account setup, making each
+  harder to debug independently
+- Burdens the initial packaging milestone with concerns that may change
+  as the project's Apple Developer relationship evolves
+
+Instead, each capability lands in its own milestone:
+
+1. **Packaging** — produce a working unsigned DMG from CI (v0.3.3)
+2. **Signing** — remove the unidentified-developer warning (v0.3.4)
+3. **Distribution** — notarize, staple, optional auto-update (v0.3.5)
+
+This ordering means packaging can be verified independently. If the DMG
+has structural problems, they are found before signing and notarization
+configuration is added on top.
+
+## Consequences
+
+- Users with a GitHub account can download a runnable Alma from the
+  Releases page without any developer tooling installed.
+- The unsigned DMG will show a Gatekeeper warning on first launch,
+  which is acceptable for an open source project at this stage.
+- A `scripts/macos/` directory centralises all packaging knowledge —
+  CI configuration stays thin and local packaging mirrors CI packaging.
+- GitHub Actions macOS runner minutes will be consumed on each tagged
+  release, but release cadence is low enough that this is not a concern.
+- The DMG format may change if future distribution methods (Homebrew,
+  Mac App Store) replace direct download as the primary channel.

--- a/scripts/macos/build.sh
+++ b/scripts/macos/build.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$PROJECT_ROOT/swift"
+
+RELEASE_TAG="${1:-}"
+VERSION="${RELEASE_TAG#v}"
+if [ -z "$VERSION" ]; then
+    VERSION="0.0.0-dev"
+fi
+
+OUTPUT_DIR="$PROJECT_ROOT/output"
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Building Alma.app (version $VERSION) ==="
+
+swift build -c release
+
+APP_BUNDLE="$OUTPUT_DIR/Alma.app"
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+cp ".build/release/Alma" "$APP_BUNDLE/Contents/MacOS/Alma"
+chmod +x "$APP_BUNDLE/Contents/MacOS/Alma"
+
+cat > "$APP_BUNDLE/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>Alma</string>
+    <key>CFBundleIdentifier</key>
+    <string>ai.palmshed.Alma</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Alma</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$VERSION</string>
+    <key>CFBundleVersion</key>
+    <string>$VERSION</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>15.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+if [ -d "Sources/Alma/Assets.xcassets" ]; then
+    xcrun actool "Sources/Alma/Assets.xcassets" \
+        --compile "$APP_BUNDLE/Contents/Resources" \
+        --platform macosx \
+        --minimum-deployment-target 15.0 \
+        --output-format human-readable-text \
+        2>&1 | grep -v "^/* com\.apple\.actool"
+fi
+
+echo "=== Alma.app built at $APP_BUNDLE ==="

--- a/scripts/macos/package.sh
+++ b/scripts/macos/package.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUTPUT_DIR="$PROJECT_ROOT/output"
+APP_BUNDLE="$OUTPUT_DIR/Alma.app"
+
+if [ ! -d "$APP_BUNDLE" ]; then
+    echo "Error: Alma.app not found at $APP_BUNDLE"
+    echo "Run build.sh first."
+    exit 1
+fi
+
+VERSION=""
+if [ -f "$APP_BUNDLE/Contents/Info.plist" ]; then
+    VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || echo "0.0.0")
+fi
+
+echo "=== Packaging Alma-$VERSION.dmg ==="
+
+STAGING_DIR=$(mktemp -d)
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+cp -R "$APP_BUNDLE" "$STAGING_DIR/Alma.app"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+DMG_PATH="$OUTPUT_DIR/Alma-$VERSION.dmg"
+rm -f "$DMG_PATH"
+
+hdiutil create \
+    -volname "Alma $VERSION" \
+    -srcfolder "$STAGING_DIR" \
+    -ov \
+    -format UDZO \
+    "$DMG_PATH" \
+    2>/dev/null
+
+echo "=== Alma.dmg packaged at $DMG_PATH ==="

--- a/scripts/macos/verify.sh
+++ b/scripts/macos/verify.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUTPUT_DIR="$PROJECT_ROOT/output"
+APP_BUNDLE="$OUTPUT_DIR/Alma.app"
+DMG_GLOB="$OUTPUT_DIR/Alma-*.dmg"
+
+errors=0
+
+check() {
+    local desc="$1"
+    if eval "$2"; then
+        echo "  ✓ $desc"
+    else
+        echo "  ✘ $desc"
+        errors=$((errors + 1))
+    fi
+}
+
+echo "=== Verifying Alma.app ==="
+
+if [ ! -d "$APP_BUNDLE" ]; then
+    echo "  ✘ Alma.app not found at $APP_BUNDLE"
+    errors=$((errors + 1))
+else
+    PLIST="$APP_BUNDLE/Contents/Info.plist"
+
+    check "Bundle exists" "test -d \"$APP_BUNDLE\""
+    check "Bundle is a directory" "test -d \"$APP_BUNDLE\""
+    check "Contents/MacOS/Alma exists" "test -f \"$APP_BUNDLE/Contents/MacOS/Alma\""
+    check "Binary is executable" "test -x \"$APP_BUNDLE/Contents/MacOS/Alma\""
+    check "Binary is not empty" "test -s \"$APP_BUNDLE/Contents/MacOS/Alma\""
+    check "Binary is a Mach-O file" "file \"$APP_BUNDLE/Contents/MacOS/Alma\" | grep -q 'Mach-O'"
+    check "Contents/Info.plist exists" "test -f \"$PLIST\""
+    check "Contents/Resources is a directory" "test -d \"$APP_BUNDLE/Contents/Resources\""
+
+    if [ -f "$PLIST" ]; then
+        check "CFBundleIdentifier is ai.palmshed.Alma" \
+            "test \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' \"$PLIST\" 2>/dev/null)\" = 'ai.palmshed.Alma'"
+        check "CFBundleExecutable is Alma" \
+            "test \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundleExecutable' \"$PLIST\" 2>/dev/null)\" = 'Alma'"
+        check "CFBundlePackageType is APPL" \
+            "test \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundlePackageType' \"$PLIST\" 2>/dev/null)\" = 'APPL'"
+        check "CFBundleVersion is set" \
+            "test -n \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundleVersion' \"$PLIST\" 2>/dev/null)\""
+        check "CFBundleShortVersionString is set" \
+            "test -n \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' \"$PLIST\" 2>/dev/null)\""
+        check "LSMinimumSystemVersion is 15.0" \
+            "test \"\$(/usr/libexec/PlistBuddy -c 'Print LSMinimumSystemVersion' \"$PLIST\" 2>/dev/null)\" = '15.0'"
+        check "NSHighResolutionCapable is true" \
+            "test \"\$(/usr/libexec/PlistBuddy -c 'Print NSHighResolutionCapable' \"$PLIST\" 2>/dev/null)\" = 'true'"
+
+        check "Version matches tag or is dev" \
+            "case \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' \"$PLIST\" 2>/dev/null)\" in 0.0.0-dev|v*) true ;; *) false ;; esac"
+    fi
+
+    if ls "$APP_BUNDLE/Contents/Resources/"*.car &>/dev/null 2>&1; then
+        check "Asset catalog compiled" "test -f \"$APP_BUNDLE/Contents/Resources/Assets.car\""
+    else
+        check "No asset catalog (empty xcassets)" "true"
+    fi
+fi
+
+echo ""
+echo "=== Verifying DMG ==="
+
+DMG_FILES=( $DMG_GLOB )
+if [ "${#DMG_FILES[@]}" -eq 0 ] || [ ! -f "${DMG_FILES[0]}" ]; then
+    echo "  ✘ No DMG found matching $DMG_GLOB"
+    errors=$((errors + 1))
+else
+    DMG="${DMG_FILES[0]}"
+    check "DMG file exists" "test -f \"$DMG\""
+    check "DMG is not empty" "test -s \"$DMG\""
+    check "DMG is a UDZO image" "hdiutil imageinfo \"$DMG\" 2>/dev/null | grep -q 'UDZO'"
+
+    MOUNT_POINT=$(mktemp -d)
+    if hdiutil attach "$DMG" -mountpoint "$MOUNT_POINT" -nobrowse 2>/dev/null; then
+        check "DMG mounts successfully" "true"
+
+        APP_COUNT=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" -type d | wc -l | tr -d ' ')
+        check "DMG contains exactly one .app" "test \"$APP_COUNT\" -eq 1"
+        check "Alma.app inside DMG" "test -d \"$MOUNT_POINT/Alma.app\""
+        check "Applications symlink inside DMG" "test -L \"$MOUNT_POINT/Applications\""
+
+        # Verify the bundle inside DMG matches the source bundle
+        if [ -d "$MOUNT_POINT/Alma.app" ] && [ -d "$APP_BUNDLE" ]; then
+            check "DMG binary size matches built binary" \
+                "test \"\$(stat -f%z \"$APP_BUNDLE/Contents/MacOS/Alma\" 2>/dev/null)\" = \"\$(stat -f%z \"$MOUNT_POINT/Alma.app/Contents/MacOS/Alma\" 2>/dev/null)\""
+            check "DMG Info.plist matches built Info.plist" \
+                "diff <(plutil -extract CFBundleShortVersionString xml1 -o - \"$APP_BUNDLE/Contents/Info.plist\" 2>/dev/null) <(plutil -extract CFBundleShortVersionString xml1 -o - \"$MOUNT_POINT/Alma.app/Contents/Info.plist\" 2>/dev/null) >/dev/null 2>&1"
+        fi
+
+        # Quick launch test: open the app and verify it doesn't crash immediately
+        if [ -n "${CI:-}" ]; then
+            # CI may not have a GUI, skip launch test
+            : 
+        elif command -v open &>/dev/null; then
+            if open "$MOUNT_POINT/Alma.app" 2>/dev/null; then
+                sleep 2
+                if pgrep -f "Alma.app" &>/dev/null; then
+                    check "App launches without immediate crash" "true"
+                    pkill -f "Alma.app" 2>/dev/null || true
+                else
+                    check "App launches without immediate crash" "false"
+                fi
+            else
+                check "App launches without immediate crash" "false"
+            fi
+        fi
+
+        hdiutil detach "$MOUNT_POINT" 2>/dev/null || true
+    else
+        check "DMG mounts successfully" "false"
+    fi
+    rm -rf "$MOUNT_POINT"
+fi
+
+echo ""
+if [ "$errors" -eq 0 ]; then
+    echo "✓ All checks passed."
+else
+    echo "✘ $errors check(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
Adds automated DMG packaging for the native macOS client.

### What's included
- ADR 0009 documenting the packaging strategy
- Local packaging scripts (build, package, verify) under scripts/macos/
- CI workflow triggered on version tags
- Alma.dmg attached as a GitHub Release asset

### Out of scope (intentional)
- Code signing
- Hardened Runtime
- Notarization
- Sparkle auto-updates

Each will be added as a separate milestone.

### Verification
- Build: `./scripts/macos/build.sh && ./scripts/macos/package.sh && ./scripts/macos/verify.sh`
- 20 verification checks pass including binary validation, DMG structure, and app launch
- Release is tagged and the DMG is published automatically