### PR TITLE
fix: accept semver versions in verify.sh version check

### DIFF
--- a/scripts/macos/verify.sh
+++ b/scripts/macos/verify.sh
@@ -52,7 +52,7 @@ else
             "test \"\$(/usr/libexec/PlistBuddy -c 'Print NSHighResolutionCapable' \"$PLIST\" 2>/dev/null)\" = 'true'"
 
         check "Version matches tag or is dev" \
-            "case \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' \"$PLIST\" 2>/dev/null)\" in 0.0.0-dev|v*) true ;; *) false ;; esac"
+            "case \"\$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' \"$PLIST\" 2>/dev/null)\" in 0.0.0-dev|[0-9]*) true ;; *) false ;; esac"
     fi
 
     if ls "$APP_BUNDLE/Contents/Resources/"*.car &>/dev/null 2>&1; then


### PR DESCRIPTION
The case pattern was checking for `v*` prefix, but build.sh strips the `v` from the tag (`v0.3.3` → `0.3.3`). Now matches digit-prefixed versions instead.

This caused the v0.3.3 CI run to fail at the verify step, which blocked the DMG from being uploaded to the GitHub Release.