### PR TITLE
fix: re-sign with fresh ad-hoc signature instead of removing it

### DIFF
--- a/scripts/macos/build.sh
+++ b/scripts/macos/build.sh
@@ -63,9 +63,14 @@ if [ -d "Sources/Alma/Assets.xcassets" ]; then
         2>&1 | grep -v "^/* com\.apple\.actool"
 fi
 
-# Remove ad-hoc signature left by swift build. The signature metadata
-# says resources must be present, but our minimal Assets.xcassets may
-# produce no Assets.car, causing Gatekeeper to reject the bundle.
-codesign --remove-signature "$APP_BUNDLE/Contents/MacOS/Alma" 2>/dev/null || true
+# Re-sign with a fresh ad-hoc signature. swift build's default ad-hoc
+# signature claims resources must be present (files=13), but our
+# minimal Assets.xcassets may produce no Assets.car. macOS sees the
+# mismatch and reports the bundle as damaged.
+#
+# codesign -s - generates a clean ad-hoc signature that correctly
+# reports zero sealed resources, producing the expected
+# "unidentified developer" Gatekeeper flow instead.
+codesign -s - --force "$APP_BUNDLE" 2>/dev/null
 
 echo "=== Alma.app built at $APP_BUNDLE ==="


### PR DESCRIPTION
**Problem**: `codesign --remove-signature` from #81 made the binary un-launchable on macOS 15 arm64. `launchd` refuses to spawn an unsigned Mach-O (POSIX error 163). The DMG passes `spctl` but the app never opens.

**Root cause**: The old fix removed the ad-hoc signature entirely, but macOS 15 requires at least an ad-hoc signature to spawn a process.

**Real fix**: `codesign -s - --force` generates a **fresh** ad-hoc signature that correctly reports zero sealed resources. Swift's default signature claimed 13 resources that don't exist (empty Assets.xcassets), causing the "damaged" error. A clean ad-hoc produces the expected "unidentified developer" Gatekeeper flow instead.

**Verification**:
- App launches from `open` ✅
- `spctl` reports expected "rejected" (unsigned developer) ✅
- `codesign -dvvv` shows `Signature=adhoc` with `files=0` ✅
- Full pipeline: build → package → verify → all 20 checks pass ✅