### PR TITLE
fix: patch mac_alias for 64-bit CNID support in CI

### DIFF
--- a/scripts/macos/package.sh
+++ b/scripts/macos/package.sh
@@ -23,6 +23,13 @@ PYENV_ROOT="$PROJECT_ROOT/.build-dsstore"
 if [ ! -d "$PYENV_ROOT" ]; then
     python3 -m venv "$PYENV_ROOT"
     "$PYENV_ROOT/bin/pip" install ds_store mac_alias -q 2>/dev/null
+    # Patch mac_alias to use 64-bit Q format for CNID path entries.
+    # APFS inode numbers exceed 32-bit range on macOS 15;
+    # the shipped v2.2.3 uses I (32-bit) and struct.pack fails.
+    ALIAS_PY="$PYENV_ROOT/lib/python*/site-packages/mac_alias/alias.py"
+    if grep -q '">%uI"' $ALIAS_PY 2>/dev/null; then
+        sed -i '' 's/">%uI"/">%uQ"/g; s/length \/\/ 4/length \/\/ 8/g' $ALIAS_PY
+    fi
 fi
 
 STAGING_DIR="$OUTPUT_DIR/.staging-$$"

--- a/scripts/macos/package.sh
+++ b/scripts/macos/package.sh
@@ -29,6 +29,7 @@ if [ ! -d "$PYENV_ROOT" ]; then
     ALIAS_PY="$PYENV_ROOT/lib/python*/site-packages/mac_alias/alias.py"
     if grep -q '">%uI"' $ALIAS_PY 2>/dev/null; then
         sed -i '' 's/">%uI"/">%uQ"/g; s/length \/\/ 4/length \/\/ 8/g' $ALIAS_PY
+        rm -rf "$PYENV_ROOT/lib/python*/site-packages/mac_alias/__pycache__"
     fi
 fi
 


### PR DESCRIPTION
## Problem

`mac_alias` v2.2.3 uses 32-bit `I` format for CNID path entries. APFS on macOS 15 uses 64-bit inode numbers, causing `struct.pack` to fail during `.DS_Store` alias generation.

## Fix

- Patch `alias.py` in `package.sh` after pip install: replace `I` with `Q` format and `length // 4` with `length // 8`
- Clear `__pycache__` after patching to avoid stale bytecode

Previously patched manually in dev venv; this makes CI work too.