### PR TITLE
fix: always patch mac_alias, not just on fresh venv install

### DIFF
--- a/scripts/macos/package.sh
+++ b/scripts/macos/package.sh
@@ -23,14 +23,14 @@ PYENV_ROOT="$PROJECT_ROOT/.build-dsstore"
 if [ ! -d "$PYENV_ROOT" ]; then
     python3 -m venv "$PYENV_ROOT"
     "$PYENV_ROOT/bin/pip" install ds_store mac_alias -q 2>/dev/null
-    # Patch mac_alias to use 64-bit Q format for CNID path entries.
-    # APFS inode numbers exceed 32-bit range on macOS 15;
-    # the shipped v2.2.3 uses I (32-bit) and struct.pack fails.
-    ALIAS_PY="$PYENV_ROOT/lib/python*/site-packages/mac_alias/alias.py"
-    if grep -q '">%uI"' $ALIAS_PY 2>/dev/null; then
-        sed -i '' 's/">%uI"/">%uQ"/g; s/length \/\/ 4/length \/\/ 8/g' $ALIAS_PY
-        rm -rf "$PYENV_ROOT/lib/python*/site-packages/mac_alias/__pycache__"
-    fi
+fi
+# Patch mac_alias to use 64-bit Q format for CNID path entries.
+# APFS inode numbers exceed 32-bit range on macOS 15;
+# the shipped v2.2.3 uses I (32-bit) and struct.pack fails.
+ALIAS_PY="$PYENV_ROOT/lib/python*/site-packages/mac_alias/alias.py"
+if grep -q '">%uI"' $ALIAS_PY 2>/dev/null; then
+    sed -i '' 's/">%uI"/">%uQ"/g; s/length \/\/ 4/length \/\/ 8/g' $ALIAS_PY
+    rm -rf "$PYENV_ROOT/lib/python*/site-packages/mac_alias/__pycache__"
 fi
 
 STAGING_DIR="$OUTPUT_DIR/.staging-$$"


### PR DESCRIPTION
The CI runner reused the `.build-dsstore` venv from the previous (failed) run, so the `if [ ! -d "$PYENV_ROOT" ]` block was skipped and the `mac_alias` patch was never applied.

Move the patching logic outside the conditional so it runs every time, regardless of whether the venv was freshly created or reused from a prior run.