### PR TITLE
fix: remove misleading Server URL field from Settings

### DIFF
--- a/swift/Sources/Alma/Features/Settings/SettingsView.swift
+++ b/swift/Sources/Alma/Features/Settings/SettingsView.swift
@@ -5,23 +5,11 @@ struct SettingsView: View {
 
     var body: some View {
         TabView {
-            generalTab
             appearanceTab
             shortcutsTab
         }
         .scenePadding()
         .frame(width: 450, height: 300)
-    }
-
-    private var generalTab: some View {
-        Form {
-            TextField("Server URL", text: .constant("http://localhost:5000"))
-                .textFieldStyle(.roundedBorder)
-        }
-        .formStyle(.grouped)
-        .tabItem {
-            Label("General", systemImage: "gearshape")
-        }
     }
 
     private var appearanceTab: some View {


### PR DESCRIPTION
Removes the General tab from Settings, which contained a hardcoded Server URL field (port 5000) that doesn't match the app's actual URL (port 8080). The field was .constant so it was not functional.