### PR TITLE
fix: clear __pycache__ after patching mac_alias to avoid stale bytecode

### DIFF
--- a/scripts/macos/package.sh
+++ b/scripts/macos/package.sh
@@ -29,8 +29,12 @@ python3 -m venv "$PYENV_ROOT"
 # Use Python to discover and patch the installed path — avoids
 # brittle globs across Python releases and shell escaping issues.
 "$PYENV_ROOT/bin/python3" -c "
-import mac_alias, pathlib
+import mac_alias, pathlib, shutil
 pkg_dir = pathlib.Path(mac_alias.__file__).resolve().parent
+# Wipe any compiled bytecode so Python recompiles from patched source
+for cache in pkg_dir.glob('__pycache__'):
+    shutil.rmtree(cache)
+    print(f'  Cleared cache: {cache}')
 patched = 0
 for f in pkg_dir.glob('*.py'):
     content = f.read_text()


### PR DESCRIPTION
The Python patch modifies `alias.py` but Python's bytecode cache (`__pycache__`) keeps the old compiled version. The subsequent DS_Store generation then loads the stale bytecode and hits the same `I` format error.

Clearing `__pycache__` after patching forces Python to recompile from source on the next import.